### PR TITLE
fix: nexgen ts module resolutions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "solid": "./dist/source/index.jsx",
       "import": "./dist/esm/index.js",
       "browser": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,6 +27,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "solid": "./dist/source/index.jsx",
       "import": "./dist/esm/index.js",
       "browser": {

--- a/packages/vanilla-extract/package.json
+++ b/packages/vanilla-extract/package.json
@@ -25,6 +25,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs",
       "require": "./dist/index.js",


### PR DESCRIPTION
Defines `types` in the exports map, so that imports work when leveraging the newer `moduleResolution` tsconfig values (nodenext, node16, bundler).

More info: https://github.com/microsoft/TypeScript/issues/52363

Note that some of the example PRs linked to from the TS issue above are adding `types` to each specific condition inside of exports. In my experiments just adding `types` to the root of the exports map resolved the issues 🤷‍♂️.

Before (after, types work as expected):

<img width="1132" alt="Screenshot 2023-02-27 at 3 25 02 PM" src="https://user-images.githubusercontent.com/847542/221689629-706e68b5-51b6-4561-aa4b-20883754fa20.png">
