### PR TITLE
fix: nexgen ts module resolutions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "solid": "./dist/index.jsx",
       "import": {
         "types": "./dist/index.d.ts",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -28,6 +28,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "solid": "./dist/index.jsx",
       "import": {
         "types": "./dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -28,6 +28,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "solid": "./dist/index.jsx",
       "import": {
         "types": "./dist/index.d.ts",


### PR DESCRIPTION
Follow-up to https://github.com/kobaltedev/kobalte/pull/124. Looks like the changes got lost in https://github.com/kobaltedev/kobalte/commit/a0ada440f5fd7617f398d48c3deea47fd3efcc81.