### PR TITLE
Feat: Add Skeleton Component

### DIFF
--- a/apps/docs/src/examples/skeleton.module.css
+++ b/apps/docs/src/examples/skeleton.module.css
@@ -1,0 +1,83 @@
+@keyframes skeleton-fade {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+.skeleton {
+  height: auto;
+  width: 100%;
+  position: relative;
+  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
+}
+.skeleton[data-animate="true"]::after {
+  animation: skeleton-fade 1500ms linear infinite;
+}
+
+.skeleton[data-visible="true"] {
+  overflow: hidden;
+}
+.skeleton[data-visible="true"]::before {
+  position: absolute;
+  content: "";
+  inset: 0;
+  z-index: 10;
+  background-color: white;
+}
+
+.skeleton[data-visible="true"]::after {
+  position: absolute;
+  content: "";
+  inset: 0;
+  z-index: 11;
+  background-color: gray;
+}
+
+.multiple-root {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.multiple-profile {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.toggle-root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.toggle-button {
+  appearance: none;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  height: 40px;
+  width: 50%;
+  outline: none;
+  border-radius: 6px;
+  background-color: hsl(200 98% 39%);
+  color: white;
+  font-size: 16px;
+  line-height: 0;
+}
+
+.toggle-button:focus-visible {
+  outline: 2px solid hsl(200 98% 39%);
+  outline-offset: 2px;
+}
+
+.toggle-button[data-pressed] {
+  background-color: hsl(0 72% 51%);
+}

--- a/apps/docs/src/examples/skeleton.tsx
+++ b/apps/docs/src/examples/skeleton.tsx
@@ -1,0 +1,58 @@
+import { Skeleton, Image, ToggleButton } from "@kobalte/core";
+import { createSignal } from "solid-js";
+import style from "./skeleton.module.css";
+
+export function BasicExample() {
+  return (
+    <Skeleton.Root class={style["skeleton"]}>
+      <p>
+        Fabien MARIE-LOUISE Developer and UI Design enthusiast. Building UI related stuffs for
+        @solid_js
+      </p>
+    </Skeleton.Root>
+  );
+}
+
+export function MultipleSkeletonsExample() {
+  return (
+    <div class={style["multiple-root"]}>
+      <div class={style["multiple-profile"]}>
+        <Skeleton.Root class={style["skeleton"]} height={50} circle>
+          <Image.Root class={style["multiple-avatar"]}>
+            <Image.Img
+              class="image__img"
+              src="https://pbs.twimg.com/profile_images/1509139491671445507/pzWYjlYN_400x400.jpg"
+              alt="Nicole Steeves"
+            />
+          </Image.Root>
+        </Skeleton.Root>
+        <Skeleton.Root class={style["skeleton"]} height={20} radius={10}>
+          Kobalte
+        </Skeleton.Root>
+      </div>
+      <Skeleton.Root class={style["skeleton"]} radius={10}>
+        <p>
+          Fabien MARIE-LOUISE Developer and UI Design enthusiast. Building UI related stuffs for
+          @solid_js
+        </p>
+      </Skeleton.Root>
+    </div>
+  );
+}
+
+export function ToggleExample() {
+  const [visible, setVisible] = createSignal(true);
+  return (
+    <div class={style["toggle-root"]}>
+      <ToggleButton.Root class={style["toggle-button"]} pressed={visible()} onChange={setVisible}>
+        Skeleton {visible() ? "Visible" : "Not Visible"}
+      </ToggleButton.Root>
+      <Skeleton.Root class={style["skeleton"]} visible={visible()}>
+        <p>
+          Fabien MARIE-LOUISE Developer and UI Design enthusiast. Building UI related stuffs for
+          @solid_js
+        </p>
+      </Skeleton.Root>
+    </div>
+  );
+}

--- a/apps/docs/src/routes/docs/core.tsx
+++ b/apps/docs/src/routes/docs/core.tsx
@@ -118,6 +118,11 @@ const CORE_NAV_SECTIONS: NavSection[] = [
         href: "/docs/core/components/separator",
       },
       {
+        title: "Skeleton",
+        href: "/docs/core/components/skeleton",
+        status: "new",
+      },
+      {
         title: "Switch",
         href: "/docs/core/components/switch",
       },

--- a/apps/docs/src/routes/docs/core/components/skeleton.mdx
+++ b/apps/docs/src/routes/docs/core/components/skeleton.mdx
@@ -1,0 +1,357 @@
+import { Preview, TabsSnippets, Kbd } from "../../../../components";
+import {
+  BasicExample,
+  MultipleSkeletonsExample,
+  ToggleExample
+} from "../../../../examples/skeleton";
+
+# Skeleton
+
+Visually indicates content loading
+
+## Import
+
+```ts
+import { Skeleton } from "@kobalte/core";
+```
+
+## Features
+
+- Support for custom width and height.
+- Support for circle skeleton.
+- Can toggle visiblity and animation properties.
+
+## Anatomy
+
+The skeleton consists of:
+
+- **Skeleton.Root:** The root container for a skeleton.
+
+```tsx
+<Skeleton.Root />
+```
+
+## Example
+
+<Preview>
+  <BasicExample />
+</Preview>
+
+<TabsSnippets>
+  <TabsSnippets.List>
+    <TabsSnippets.Trigger value="index.tsx">index.tsx</TabsSnippets.Trigger>
+    <TabsSnippets.Trigger value="style.css">style.css</TabsSnippets.Trigger>
+  </TabsSnippets.List>
+{/* <!-- prettier-ignore-start -->*/}
+  <TabsSnippets.Content value="index.tsx">
+    ```tsx
+    import { Skeleton } from "@kobalte/core";
+    import "./style.css";
+
+    function App() {
+      return (
+      <Skeleton.Root class="skeleton" radius={10}>
+        <p>
+          Fabien MARIE-LOUISE Developer and UI Design enthusiast. Building UI related stuffs for
+          @solid_js
+        </p>
+      </Skeleton.Root>
+      );
+    }
+    ```
+
+  </TabsSnippets.Content>
+  <TabsSnippets.Content value="style.css">
+    ```css
+    @keyframes skeleton-fade {
+      0%,
+      100% {
+        opacity: 0.4;
+      }
+
+      50% {
+        opacity: 1;
+      }
+    }
+
+    .skeleton {
+      height: auto;
+      width: 100%;
+      position: relative;
+      transform: translateZ(0);
+      -webkit-transform: translateZ(0);
+    }
+    .skeleton[data-animate="true"]::after {
+      animation: skeleton-fade 1500ms linear infinite;
+    }
+
+    .skeleton[data-visible="true"] {
+      overflow: hidden;
+    }
+    .skeleton[data-visible="true"]::before {
+      position: absolute;
+      content: "";
+      inset: 0;
+      z-index: 10;
+      background-color: white;
+    }
+
+    .skeleton[data-visible="true"]::after {
+      position: absolute;
+      content: "";
+      inset: 0;
+      z-index: 11;
+      background-color: gray;
+    }
+    ```
+
+  </TabsSnippets.Content>
+{/* <!-- prettier-ignore-end -->*/}
+</TabsSnippets>
+
+## Usage
+
+### Multiple skeletons
+<Preview>
+  <MultipleSkeletonsExample />
+</Preview>
+
+<TabsSnippets>
+  <TabsSnippets.List>
+    <TabsSnippets.Trigger value="index.tsx">index.tsx</TabsSnippets.Trigger>
+    <TabsSnippets.Trigger value="style.css">style.css</TabsSnippets.Trigger>
+  </TabsSnippets.List>
+{/* <!-- prettier-ignore-start -->*/}
+  <TabsSnippets.Content value="index.tsx">
+    ```tsx
+    import { Skeleton, Image } from "@kobalte/core";
+    import "./style.css";
+
+    function App() {
+      return (
+        <div class="multiple-root">
+          <div class="multiple-profile">
+            <Skeleton.Root class="skeleton" height={50} circle>
+              <Image.Root class="multiple-avatar">
+                <Image.Img
+                  class="image__img"
+                  src="https://pbs.twimg.com/profile_images/1509139491671445507/pzWYjlYN_400x400.jpg"
+                  alt="Nicole Steeves"
+                />
+              </Image.Root>
+            </Skeleton.Root>
+            <Skeleton.Root class="skeleton" height={20} radius={10}>
+              Kobalte
+            </Skeleton.Root>
+          </div>
+          <Skeleton.Root class="skeleton" radius={10}>
+            <p>
+              Fabien MARIE-LOUISE Developer and UI Design enthusiast. Building UI related stuffs for
+              @solid_js
+            </p>
+          </Skeleton.Root>
+        </div>
+      );
+    }
+    ```
+
+  </TabsSnippets.Content>
+  <TabsSnippets.Content value="style.css">
+    ```css
+    @keyframes skeleton-fade {
+      0%,
+      100% {
+        opacity: 0.4;
+      }
+
+      50% {
+        opacity: 1;
+      }
+    }
+
+    .skeleton {
+      height: auto;
+      width: 100%;
+      position: relative;
+      transform: translateZ(0);
+      -webkit-transform: translateZ(0);
+    }
+    .skeleton[data-animate="true"]::after {
+      animation: skeleton-fade 1500ms linear infinite;
+    }
+
+    .skeleton[data-visible="true"] {
+      overflow: hidden;
+    }
+    .skeleton[data-visible="true"]::before {
+      position: absolute;
+      content: "";
+      inset: 0;
+      z-index: 10;
+      background-color: white;
+    }
+
+    .skeleton[data-visible="true"]::after {
+      position: absolute;
+      content: "";
+      inset: 0;
+      z-index: 11;
+      background-color: gray;
+    }
+
+    .multiple-root {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .multiple-profile {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+    }
+    ```
+
+  </TabsSnippets.Content>
+{/* <!-- prettier-ignore-end -->*/}
+</TabsSnippets>
+
+### Toggle example
+<Preview>
+  <ToggleExample />
+</Preview>
+
+<TabsSnippets>
+  <TabsSnippets.List>
+    <TabsSnippets.Trigger value="index.tsx">index.tsx</TabsSnippets.Trigger>
+    <TabsSnippets.Trigger value="style.css">style.css</TabsSnippets.Trigger>
+  </TabsSnippets.List>
+{/* <!-- prettier-ignore-start -->*/}
+  <TabsSnippets.Content value="index.tsx">
+    ```tsx
+    import { Skeleton, ToggleButton } from "@kobalte/core";
+    import "./style.css";
+
+    function App() {
+      const [visible, setVisible] = createSignal(true);
+      return (
+        <div class="toggle-root">
+          <ToggleButton.Root class="toggle-button" pressed={visible()} onChange={setVisible}>
+            Skeleton {visible() ? "Visible" : "Not Visible"}
+          </ToggleButton.Root>
+          <Skeleton.Root class="skeleton" visible={visible()}>
+            <p>
+              Fabien MARIE-LOUISE Developer and UI Design enthusiast. Building UI related stuffs for
+              @solid_js
+            </p>
+          </Skeleton.Root>
+        </div>
+      );
+    }
+    ```
+
+  </TabsSnippets.Content>
+  <TabsSnippets.Content value="style.css">
+    ```css
+    @keyframes skeleton-fade {
+      0%,
+      100% {
+        opacity: 0.4;
+      }
+
+      50% {
+        opacity: 1;
+      }
+    }
+
+    .skeleton {
+      height: auto;
+      width: 100%;
+      position: relative;
+      transform: translateZ(0);
+      -webkit-transform: translateZ(0);
+    }
+    .skeleton[data-animate="true"]::after {
+      animation: skeleton-fade 1500ms linear infinite;
+    }
+
+    .skeleton[data-visible="true"] {
+      overflow: hidden;
+    }
+    .skeleton[data-visible="true"]::before {
+      position: absolute;
+      content: "";
+      inset: 0;
+      z-index: 10;
+      background-color: white;
+    }
+
+    .skeleton[data-visible="true"]::after {
+      position: absolute;
+      content: "";
+      inset: 0;
+      z-index: 11;
+      background-color: gray;
+    }
+
+    .toggle-root {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .toggle-button {
+      appearance: none;
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      height: 40px;
+      width: 50%;
+      outline: none;
+      border-radius: 6px;
+      background-color: hsl(200 98% 39%);
+      color: white;
+      font-size: 16px;
+      line-height: 0;
+    }
+
+    .toggle-button:focus-visible {
+      outline: 2px solid hsl(200 98% 39%);
+      outline-offset: 2px;
+    }
+
+    .toggle-button[data-pressed] {
+      background-color: hsl(0 72% 51%);
+    }
+    ```
+
+  </TabsSnippets.Content>
+{/* <!-- prettier-ignore-end -->*/}
+</TabsSnippets>
+
+## API Reference
+
+### Skeleton.Root
+
+| Prop            | Description                                                                                                                                                                   |
+| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| visible         | `boolean` <br/> The visible state of the Skeleton. Sets the `data-visible` data attribute.                                                                                                                 |
+| animate  | `boolean` <br/> Whether the skeleton should animate. Sets the `data-animate` data attribute.                                                  |
+| width        | `number` <br/> The width of the skeleton in px. Defaults to 100%.                                                                       |
+| height   | `number` <br/> The height of the skeleton in px. Defaults to auto.                                                                                                            |
+| radius   | `number` <br/> Roundness of the skeleton in px. Sets border-radius.                                                                                                            |
+| circle   | `boolean` <br/> Whether the skeleton should be a circle. Sets border-radius and width to the height.                                                                                                            |
+| children        | `JSX.Element` <br/> The children of the Skeleton. |
+
+| Data attribute     | Description                                                             |
+| :----------------- | :---------------------------------------------------------------------- |
+| data-visible         | Present when the Skeleton is visible.   |
+| data-animate       | Present when the Skeleton can animate. |
+
+
+## Rendered elements
+
+| Component               | Default rendered element |
+| :---------------------- | :----------------------- |
+| `Skeleton.Root`         | `div`                    |

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -33,6 +33,7 @@ export * as Progress from "./progress";
 export * as RadioGroup from "./radio-group";
 export * as Select from "./select";
 export * as Separator from "./separator";
+export * as Skeleton from "./skeleton";
 //export * as Slider from "./slider";
 export * as Switch from "./switch";
 export * as Tabs from "./tabs";

--- a/packages/core/src/skeleton/index.tsx
+++ b/packages/core/src/skeleton/index.tsx
@@ -1,0 +1,1 @@
+export { Skeleton as Root } from "./skeleton";

--- a/packages/core/src/skeleton/skeleton.tsx
+++ b/packages/core/src/skeleton/skeleton.tsx
@@ -1,0 +1,68 @@
+import { mergeDefaultProps, OverrideComponentProps } from "@kobalte/utils";
+import { createUniqueId, JSX, splitProps } from "solid-js";
+import { Polymorphic } from "../polymorphic";
+
+interface SkeletonOptions {
+  /** Whether the skeleton is visible. Sets data attribute. */
+  visible?: boolean;
+
+  /** Width of skeleton in `px`. Defaults to `100%` */
+  width?: number;
+
+  /** Height of skeleton in `px`. Defaults to `auto` */
+  height?: number;
+
+  /** Whether skeleton should be a circle. Sets `border-radius` and `width` to `height`. */
+  circle?: boolean;
+
+  /** Roundedness of skeleton in `px`. */
+  radius?: number;
+
+  /** Whether the skeleton should animate. */
+  animate?: boolean;
+
+  /** The HTML styles attribute (object form only). */
+  style?: JSX.CSSProperties;
+}
+
+export interface SkeletonProps extends OverrideComponentProps<"div", SkeletonOptions> {}
+
+export function Skeleton(props: SkeletonProps) {
+  const defaultId = `skeleton-${createUniqueId()}`;
+
+  props = mergeDefaultProps(
+    {
+      visible: true,
+      animate: true,
+      id: defaultId,
+    },
+    props
+  );
+
+  const [local, others] = splitProps(props, [
+    "style",
+    "ref",
+    "radius",
+    "animate",
+    "height",
+    "width",
+    "visible",
+    "circle",
+  ]);
+
+  return (
+    <Polymorphic
+      as="div"
+      role="group"
+      data-animate={local.animate}
+      data-visible={local.visible}
+      style={{
+        "border-radius": local.circle ? "9999px" : local.radius ? `${local.radius}px` : undefined,
+        width: local.circle ? `${local.height}px` : local.width ? `${local.width}px` : "100%",
+        height: local.height ? `${local.height}px` : "auto",
+        ...local.style,
+      }}
+      {...others}
+    ></Polymorphic>
+  );
+}

--- a/packages/core/src/skeleton/skeleton.tsx
+++ b/packages/core/src/skeleton/skeleton.tsx
@@ -1,3 +1,10 @@
+/*!
+ * Portions of this file are based on code from Mantine.
+ * MIT Licensed, Copyright (c) 2021 Vitaly Rtishchev.
+ *
+ * Credits to the Mantine team:
+ * https://github.com/mantinedev/mantine/blob/master/src/mantine-core/src/components/Skeleton/Skeleton.tsx
+ */
 import { mergeDefaultProps, OverrideComponentProps } from "@kobalte/utils";
 import { createUniqueId, JSX, splitProps } from "solid-js";
 import { Polymorphic } from "../polymorphic";
@@ -36,7 +43,7 @@ export function Skeleton(props: SkeletonProps) {
       animate: true,
       id: defaultId,
     },
-    props
+    props,
   );
 
   const [local, others] = splitProps(props, [

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -24,6 +24,8 @@ const STATES = [
   "highlighted",
   "current",
   "placeholder-shown",
+  "visible",
+  "animate",
 ];
 const ORIENTATIONS = ["horizontal", "vertical"];
 const SWIPE_STATES = ["start", "move", "cancel", "end"];


### PR DESCRIPTION
This PR introduces the Skeleton component ported from the [Mantine implementation](https://mantine.dev/core/skeleton/) with the following features:

- Ability to set whether the skeleton is visible or not. This sets a data attribute and it is up to the user to set the styles when the skeleton isn't visible.
- Ability to set whether the skeleton should animate. This sets a data attribute and it is up to the user to set the styles for when the skeleton is animatable.
- `Width`, `Height`, and `Radius` props to set the width, height, and border-radius of the skeleton in `px`.
- `Circle` prop for making the skeleton a circle using the height provided.

Some possible changes:
- Add a default animation
- Rename attributes