### PR TITLE
fix(combobox): filtering of option groups

### DIFF
--- a/packages/core/src/combobox/combobox-base.tsx
+++ b/packages/core/src/combobox/combobox-base.tsx
@@ -418,16 +418,23 @@ export function ComboboxBase<Option, OptGroup = never>(props: ComboboxBaseProps<
       return (local.options as Option[]).filter(filterFn);
     }
 
-    return local.options.filter(optGroup => {
+    let filteredGroups: OptGroup[] = [];
+    for (const optGroup of local.options as OptGroup[]) {
+      // Filter options of the group
       const filteredChildrenOptions = ((optGroup as any)[optionGroupChildren] as Option[]).filter(
         filterFn,
       );
+      // Don't add any groups that are empty
+      if (filteredChildrenOptions.length === 0) continue;
 
-      return {
+      // Add the group with the filtered options
+      filteredGroups.push({
         ...optGroup,
         [optionGroupChildren]: filteredChildrenOptions,
-      };
-    });
+      });
+    }
+
+    return filteredGroups;
   });
 
   const displayedOptions = createMemo(() => {


### PR DESCRIPTION
Fixes #272 

Main issue was the use of ``filter`` on ``local.options`` which was returning the original array of options rather than actually filtering them out. 

Switching to a ``map`` or ``for..of`` loop was the solution. I opted for the ``for..of`` solution to avoid having the filter for undefined values afterwards.