### PR TITLE
fix(slider): fix bugs with thumb

### DIFF
--- a/packages/core/src/slider/slider-context.tsx
+++ b/packages/core/src/slider/slider-context.tsx
@@ -16,7 +16,7 @@ export interface SliderContextValue {
   state: SliderState;
   thumbs: Accessor<CollectionItemWithRef[]>;
   setThumbs: Setter<CollectionItemWithRef[]>;
-  onSlideStart: ((value: number) => void) | undefined;
+  onSlideStart: ((index: number, value: number) => void) | undefined;
   onSlideMove: ((deltas: { deltaX: number; deltaY: number }) => void) | undefined;
   onSlideEnd: (() => void) | undefined;
   onStepKeyDown: (event: KeyboardEvent, index: number) => void;

--- a/packages/core/src/slider/slider-root.tsx
+++ b/packages/core/src/slider/slider-root.tsx
@@ -205,14 +205,11 @@ export function SliderRoot(props: SliderRootProps) {
   const [trackRef, setTrackRef] = createSignal<HTMLElement>();
 
   let currentPosition: number | null = null;
-  const onSlideStart = (value: number) => {
-    const closestIndex = getClosestValueIndex(state.values(), value);
-    if (closestIndex >= 0) {
-      state.setFocusedThumb(closestIndex);
-      state.setThumbDragging(closestIndex, true);
-      state.setThumbValue(closestIndex, value);
-      currentPosition = null;
-    }
+  const onSlideStart = (index: number, value: number) => {
+    state.setFocusedThumb(index);
+    state.setThumbDragging(index, true);
+    state.setThumbValue(index, value);
+    currentPosition = null;
   };
 
   const onSlideMove = ({ deltaX, deltaY }: { deltaX: number; deltaY: number }) => {

--- a/packages/core/src/slider/slider-thumb.tsx
+++ b/packages/core/src/slider/slider-thumb.tsx
@@ -13,7 +13,15 @@
  */
 
 import { callHandler, mergeDefaultProps, mergeRefs, OverrideComponentProps } from "@kobalte/utils";
-import { Accessor, createContext, JSX, onMount, splitProps, useContext } from "solid-js";
+import {
+  Accessor,
+  createContext,
+  createUniqueId,
+  JSX,
+  onMount,
+  splitProps,
+  useContext,
+} from "solid-js";
 
 import { createFormControlField, FORM_CONTROL_FIELD_PROP_NAMES } from "../form-control";
 import { AsChildProp, Polymorphic } from "../polymorphic";
@@ -33,7 +41,7 @@ export function SliderThumb(props: SliderThumbProps) {
 
   props = mergeDefaultProps(
     {
-      id: context.generateId("thumb"),
+      id: context.generateId(`thumb-${createUniqueId()}`),
     },
     props,
   );
@@ -101,18 +109,20 @@ export function SliderThumb(props: SliderThumbProps) {
 
     const target = e.currentTarget as HTMLElement;
 
-    target.setPointerCapture(e.pointerId);
     e.preventDefault();
+    e.stopPropagation();
+    target.setPointerCapture(e.pointerId);
     target.focus();
 
     startPosition = context.state.orientation() === "horizontal" ? e.clientX : e.clientY;
 
-    if (value()) {
-      context.onSlideStart?.(value()!);
+    if (value() !== undefined) {
+      context.onSlideStart?.(index(), value()!);
     }
   };
 
   const onPointerMove: JSX.EventHandlerUnion<any, PointerEvent> = e => {
+    e.stopPropagation();
     callHandler(e, local.onPointerMove);
 
     const target = e.currentTarget as HTMLElement;
@@ -129,6 +139,7 @@ export function SliderThumb(props: SliderThumbProps) {
   };
 
   const onPointerUp: JSX.EventHandlerUnion<any, PointerEvent> = e => {
+    e.stopPropagation();
     callHandler(e, local.onPointerUp);
 
     const target = e.currentTarget as HTMLElement;

--- a/packages/core/src/slider/slider-track.tsx
+++ b/packages/core/src/slider/slider-track.tsx
@@ -3,7 +3,7 @@ import { createSignal, JSX, splitProps } from "solid-js";
 
 import { AsChildProp, Polymorphic } from "../polymorphic";
 import { useSliderContext } from "./slider-context";
-import { linearScale } from "./utils";
+import { getClosestValueIndex, linearScale } from "./utils";
 
 export interface SliderTrackProps extends OverrideComponentProps<"div", AsChildProp> {}
 
@@ -58,7 +58,8 @@ export function SliderTrack(props: SliderTrackProps) {
       context.state.orientation() === "horizontal" ? e.clientX : e.clientY,
     );
     startPosition = context.state.orientation() === "horizontal" ? e.clientX : e.clientY;
-    context.onSlideStart?.(value);
+    const closestIndex = getClosestValueIndex(context.state.values(), value);
+    context.onSlideStart?.(closestIndex, value);
   };
 
   const onPointerMove: JSX.EventHandlerUnion<any, PointerEvent> = e => {


### PR DESCRIPTION
Fixed issue with thumbs moving too fast which was caused by the `Track` receiving pointer events. Fixed by adding `stopPropagation`. 

Fixed issue with the wrong thumb being selected when thumb values are 0 and they overlap.

Changed `onSlideStart` to take in an index and a value. Thumbs pass in their own index and track will use `getClosestValueIndex` method to calculate the thumb that needs to be moved.