### PR TITLE
fix(slider): fix `Home/End/PageDown/PageUp` keys

### DIFF
--- a/apps/docs/src/examples/slider.tsx
+++ b/apps/docs/src/examples/slider.tsx
@@ -31,7 +31,7 @@ export function MultipleThumbsExample() {
         <Slider.Thumb class={style["SliderThumb"]}>
           <Slider.Input />
         </Slider.Thumb>
-        <Slider.Thumb class={`${style["SliderThumb"]} ${style["SliderThumb"]}`}>
+        <Slider.Thumb class={style["SliderThumb"]}>
           <Slider.Input />
         </Slider.Thumb>
       </Slider.Track>
@@ -94,7 +94,7 @@ export function MinStepsBetweenExample() {
         <Slider.Thumb class={style["SliderThumb"]}>
           <Slider.Input />
         </Slider.Thumb>
-        <Slider.Thumb class={`${style["SliderThumb"]} ${style["SliderThumb"]}`}>
+        <Slider.Thumb class={style["SliderThumb"]}>
           <Slider.Input />
         </Slider.Thumb>
       </Slider.Track>
@@ -137,7 +137,7 @@ export function CustomValueLabelExample() {
         <Slider.Thumb class={style["SliderThumb"]}>
           <Slider.Input />
         </Slider.Thumb>
-        <Slider.Thumb class={`${style["SliderThumb"]} ${style["SliderThumb"]}`}>
+        <Slider.Thumb class={style["SliderThumb"]}>
           <Slider.Input />
         </Slider.Thumb>
       </Slider.Track>

--- a/packages/core/src/slider/create-slider-state.ts
+++ b/packages/core/src/slider/create-slider-state.ts
@@ -121,11 +121,17 @@ export function createSliderState(props: StateOpts): SliderState {
   };
 
   const getThumbMinValue = (index: number) => {
-    return index === 0 ? props.minValue!() : values()[index - 1];
+    return index === 0
+      ? props.minValue!()
+      : values()[index - 1] +
+          props.minStepsBetweenThumbs!() * props.step!() * (values().length - 1);
   };
 
   const getThumbMaxValue = (index: number) => {
-    return index === values().length - 1 ? props.maxValue!() : values()[index + 1];
+    return index === values().length - 1
+      ? props.maxValue!()
+      : values()[index + 1] -
+          props.minStepsBetweenThumbs!() * props.step!() * (values().length - 1);
   };
 
   const isThumbEditable = (index: number) => {
@@ -182,9 +188,8 @@ export function createSliderState(props: StateOpts): SliderState {
     return clamp(getRoundedValue(val), props.minValue!(), props.maxValue!());
   };
 
-  const incrementThumb = (index: number, stepSize = 1) => {
-    const s = Math.max(stepSize, props.step!());
-    const nextValue = values()[index] + s;
+  const snapThumbValue = (index: number, value: number) => {
+    const nextValue = values()[index] + value;
     const nextValues = getNextSortedValues(values(), nextValue, index);
     if (hasMinStepsBetweenValues(nextValues, props.minStepsBetweenThumbs!() * props.step!())) {
       updateValue(
@@ -194,16 +199,12 @@ export function createSliderState(props: StateOpts): SliderState {
     }
   };
 
+  const incrementThumb = (index: number, stepSize = 1) => {
+    snapThumbValue(index, Math.max(stepSize, props.step!()));
+  };
+
   const decrementThumb = (index: number, stepSize = 1) => {
-    const s = Math.max(stepSize, props.step!());
-    const nextValue = values()[index] - s;
-    const nextValues = getNextSortedValues(values(), nextValue, index);
-    if (hasMinStepsBetweenValues(nextValues, props.minStepsBetweenThumbs!() * props.step!())) {
-      updateValue(
-        index,
-        snapValueToStep(nextValue, props.minValue!(), props.maxValue!(), props.step!()),
-      );
-    }
+    snapThumbValue(index, -Math.max(stepSize, props.step!()));
   };
 
   return {

--- a/packages/core/src/slider/create-slider-state.ts
+++ b/packages/core/src/slider/create-slider-state.ts
@@ -123,15 +123,13 @@ export function createSliderState(props: StateOpts): SliderState {
   const getThumbMinValue = (index: number) => {
     return index === 0
       ? props.minValue!()
-      : values()[index - 1] +
-          props.minStepsBetweenThumbs!() * props.step!() * (values().length - 1);
+      : values()[index - 1] + props.minStepsBetweenThumbs!() * props.step!();
   };
 
   const getThumbMaxValue = (index: number) => {
     return index === values().length - 1
       ? props.maxValue!()
-      : values()[index + 1] -
-          props.minStepsBetweenThumbs!() * props.step!() * (values().length - 1);
+      : values()[index + 1] - props.minStepsBetweenThumbs!() * props.step!();
   };
 
   const isThumbEditable = (index: number) => {

--- a/packages/core/src/slider/slider-input.tsx
+++ b/packages/core/src/slider/slider-input.tsx
@@ -74,7 +74,7 @@ export function SliderInput(props: SliderInputProps) {
       type="range"
       id={fieldProps.id()}
       name={formControlContext.name()}
-      tabIndex={!context.state.isDisabled() ? 0 : undefined}
+      tabIndex={context.state.isDisabled() ? undefined : -1}
       min={context.state.getThumbMinValue(thumb.index())}
       max={context.state.getThumbMaxValue(thumb.index())}
       step={context.state.step()}

--- a/packages/core/src/slider/slider-root.tsx
+++ b/packages/core/src/slider/slider-root.tsx
@@ -251,6 +251,7 @@ export function SliderRoot(props: SliderRootProps) {
     if (activeThumb !== undefined) {
       state.setThumbDragging(activeThumb, false);
       local.onChangeEnd?.(state.values());
+      (thumbs()[activeThumb].ref() as HTMLElement).focus();
     }
   };
 

--- a/packages/core/src/slider/slider-root.tsx
+++ b/packages/core/src/slider/slider-root.tsx
@@ -26,7 +26,11 @@ import { CollectionItemWithRef, createFormResetListener } from "../primitives";
 import { createDomCollection } from "../primitives/create-dom-collection";
 import { createSliderState } from "./create-slider-state";
 import { SliderContext, SliderContextValue, SliderDataSet } from "./slider-context";
-import { getClosestValueIndex, getNextSortedValues, hasMinStepsBetweenValues } from "./utils";
+import {
+  getNextSortedValues,
+  hasMinStepsBetweenValues,
+  stopEventDefaultAndPropagation,
+} from "./utils";
 
 export interface GetValueLabelParams {
   values: number[];
@@ -250,19 +254,22 @@ export function SliderRoot(props: SliderRootProps) {
     }
   };
 
-  const onHomeKeyDown = () => {
-    !formControlContext.isDisabled() &&
-      state.focusedThumb() !== undefined &&
-      state.setThumbValue(0, state.getThumbMinValue(0));
+  const onHomeKeyDown = (event: KeyboardEvent) => {
+    const focusedThumb = state.focusedThumb();
+
+    if (!formControlContext.isDisabled() && focusedThumb !== undefined) {
+      stopEventDefaultAndPropagation(event);
+      state.setThumbValue(focusedThumb, state.getThumbMinValue(focusedThumb));
+    }
   };
 
-  const onEndKeyDown = () => {
-    !formControlContext.isDisabled() &&
-      state.focusedThumb() !== undefined &&
-      state.setThumbValue(
-        state.values().length - 1,
-        state.getThumbMaxValue(state.values().length - 1),
-      );
+  const onEndKeyDown = (event: KeyboardEvent) => {
+    const focusedThumb = state.focusedThumb();
+
+    if (!formControlContext.isDisabled() && focusedThumb !== undefined) {
+      stopEventDefaultAndPropagation(event);
+      state.setThumbValue(focusedThumb, state.getThumbMaxValue(focusedThumb));
+    }
   };
 
   const onStepKeyDown = (event: KeyboardEvent, index: number) => {
@@ -270,8 +277,9 @@ export function SliderRoot(props: SliderRootProps) {
       switch (event.key) {
         case "Left":
         case "ArrowLeft":
-          event.preventDefault();
-          event.stopPropagation();
+        case "Down":
+        case "ArrowDown":
+          stopEventDefaultAndPropagation(event);
           if (!isLTR()) {
             state.incrementThumb(index, event.shiftKey ? state.pageSize() : state.step());
           } else {
@@ -280,44 +288,27 @@ export function SliderRoot(props: SliderRootProps) {
           break;
         case "Right":
         case "ArrowRight":
-          event.preventDefault();
-          event.stopPropagation();
-          if (!isLTR()) {
-            state.decrementThumb(index, event.shiftKey ? state.pageSize() : state.step());
-          } else {
-            state.incrementThumb(index, event.shiftKey ? state.pageSize() : state.step());
-          }
-          break;
         case "Up":
         case "ArrowUp":
-          event.preventDefault();
-          event.stopPropagation();
+          stopEventDefaultAndPropagation(event);
           if (!isLTR()) {
             state.decrementThumb(index, event.shiftKey ? state.pageSize() : state.step());
           } else {
             state.incrementThumb(index, event.shiftKey ? state.pageSize() : state.step());
-          }
-          break;
-        case "Down":
-        case "ArrowDown":
-          event.preventDefault();
-          event.stopPropagation();
-          if (!isLTR()) {
-            state.incrementThumb(index, event.shiftKey ? state.pageSize() : state.step());
-          } else {
-            state.decrementThumb(index, event.shiftKey ? state.pageSize() : state.step());
           }
           break;
         case "Home":
-          onHomeKeyDown();
+          onHomeKeyDown(event);
           break;
         case "End":
-          onEndKeyDown();
+          onEndKeyDown(event);
           break;
         case "PageUp":
+          stopEventDefaultAndPropagation(event);
           state.incrementThumb(index, state.pageSize());
           break;
         case "PageDown":
+          stopEventDefaultAndPropagation(event);
           state.decrementThumb(index, state.pageSize());
           break;
       }

--- a/packages/core/src/slider/slider-root.tsx
+++ b/packages/core/src/slider/slider-root.tsx
@@ -276,9 +276,7 @@ export function SliderRoot(props: SliderRootProps) {
   const onStepKeyDown = (event: KeyboardEvent, index: number) => {
     if (!formControlContext.isDisabled()) {
       switch (event.key) {
-        case "Left":
         case "ArrowLeft":
-        case "Down":
         case "ArrowDown":
           stopEventDefaultAndPropagation(event);
           if (!isLTR()) {
@@ -287,9 +285,7 @@ export function SliderRoot(props: SliderRootProps) {
             state.decrementThumb(index, event.shiftKey ? state.pageSize() : state.step());
           }
           break;
-        case "Right":
         case "ArrowRight":
-        case "Up":
         case "ArrowUp":
           stopEventDefaultAndPropagation(event);
           if (!isLTR()) {

--- a/packages/core/src/slider/slider-root.tsx
+++ b/packages/core/src/slider/slider-root.tsx
@@ -276,7 +276,9 @@ export function SliderRoot(props: SliderRootProps) {
   const onStepKeyDown = (event: KeyboardEvent, index: number) => {
     if (!formControlContext.isDisabled()) {
       switch (event.key) {
+        case "Left":
         case "ArrowLeft":
+        case "Down":
         case "ArrowDown":
           stopEventDefaultAndPropagation(event);
           if (!isLTR()) {
@@ -285,7 +287,9 @@ export function SliderRoot(props: SliderRootProps) {
             state.decrementThumb(index, event.shiftKey ? state.pageSize() : state.step());
           }
           break;
+        case "Right":
         case "ArrowRight":
+        case "Up":
         case "ArrowUp":
           stopEventDefaultAndPropagation(event);
           if (!isLTR()) {

--- a/packages/core/src/slider/utils.ts
+++ b/packages/core/src/slider/utils.ts
@@ -16,7 +16,9 @@ export function getClosestValueIndex(values: number[], nextValue: number) {
   if (values.length === 1) return 0;
   const distances = values.map(value => Math.abs(value - nextValue));
   const closestDistance = Math.min(...distances);
-  return distances.indexOf(closestDistance);
+  const closestIndex = distances.indexOf(closestDistance);
+
+  return nextValue < values[closestIndex] ? closestIndex : distances.lastIndexOf(closestDistance);
 }
 
 /**

--- a/packages/core/src/slider/utils.ts
+++ b/packages/core/src/slider/utils.ts
@@ -68,3 +68,8 @@ export function linearScale(input: readonly [number, number], output: readonly [
     return output[0] + ratio * (value - input[0]);
   };
 }
+
+export function stopEventDefaultAndPropagation(event: Event) {
+  event.preventDefault();
+  event.stopPropagation();
+}


### PR DESCRIPTION
Fixed the following issues with the [`Slider`](https://kobalte.dev/docs/core/components/slider):

* When using  `Home/End/PageDown/PageUp` keys, the page would scroll instead of staying in place and updating the slider values. This is not the intended behavior, so the default event is prevented and the propagation is stopped to fix it. This was reused in many places across the slider, so I abstracted it into a `util` called `stopEventDefaultAndPropagation` (feel free to ask me to bring back the old behavior with less function calls).

* Slider behavior wasn't aligned with the WAI-ARIA Multi-Thumb slider: When you have a [Multi-Thumb Slider](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb/examples/slider-multithumb/) and you press the `Home/End` key, the expectation is for the currently focused thumb to go as far as it's allowed, but the current implementation simply forced the `Home` key to snap the first thumb at the min value and the `End` key to snap the second thumb to the max value. This PR addresses that by grabbing the `min/max` values for the focused thumb instead of a fixed index. I also made the `getThumbMinValue/getThumbMaxValue` functions aware of the `minStepsBetweenThumbs`.

* Simplifies increment / decrement thumb: abstracted their repeated code into a function called `snapThumbValue` (same mention here regarding bringing back the old behavior for less function calls).

* Removed unused import of `getClosestValueIndex` in `slider-root.tsx`.

* Simplified the fall-through cases for the `switch` statement that handles the slider keys.

* Fixed `getClosestValueIndex` to resolve ambigous values.

* Focus the correct thumb after `onSlideEnd`.

~A small comment that I've noticed and currently cannot wrap my head around: Why are there 2 focus points between sliders (both the thumb and the hidden input are focusable, creating the need for two `tab` key presses before switching focus)? This issue is not present in [`React-ARIA`'s `RangeSlider`](https://react-spectrum.adobe.com/react-spectrum/RangeSlider.html#rangeslider). I think this could also be addressed setting `tabIndex={-1}` for the inputs.
Let me know if this PR should also incorporate that change.~

Thanks as always for such a nice library!