### PR TITLE
fix: stop propagation in context menu trigger

### DIFF
--- a/packages/core/src/context-menu/context-menu-trigger.tsx
+++ b/packages/core/src/context-menu/context-menu-trigger.tsx
@@ -75,6 +75,7 @@ export function ContextMenuTrigger(props: ContextMenuTriggerProps) {
     clearLongPressTimeout();
 
     e.preventDefault();
+    e.stopPropagation();
 
     context.setAnchorRect({ x: e.clientX, y: e.clientY });
 


### PR DESCRIPTION
This allows nested context menus - div with context menu containing another div with different context menu.