### PR TITLE
build: remove git hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,3 +119,12 @@ Kobalte follows the [conventional commits](https://www.conventionalcommits.org/e
 We use [jest](https://jestjs.io/) for unit tests and [@solidjs/testing-library](https://github.com/solidjs/@solidjs/testing-library) for rendering and writing assertions. Please make sure you include tests with your pull requests. Our CI will run the tests on PRs, you can see on each PR whether you have passed all our checks.
 
 - To run tests locally - `pnpm test`.
+
+### Pull Request
+
+Before opening a pull request be sure to test and run the following checks:
+
+- Format - `pnpm format`
+- Check lint - `pnpm check`
+
+To apply automatic lints run `pnpm lint`

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "rollup": "3.28.1",
     "rollup-preset-solid": "2.0.1",
     "solid-js": "1.7.11",
-    "sort-package-json": "2.5.1",
     "ts-jest": "28.0.8",
     "tsup": "7.2.0",
     "turbo": "1.10.13",

--- a/package.json
+++ b/package.json
@@ -26,18 +26,8 @@
 		"format": "biome format . --write && prettier . --write",
 		"lint": "pnpm check --apply",
 		"check": "biome check .",
-    "prepare": "husky install",
     "test": "turbo run test",
     "typecheck": "turbo run typecheck"
-  },
-  "lint-staged": {
-    "*.{md,json}": [
-      "prettier --write"
-    ],
-    "*.ts?(x)": [
-      "prettier --write"
-    ],
-    "package.json": "npx sort-package-json"
   },
   "config": {
     "commitizen": {
@@ -62,11 +52,9 @@
     "@types/testing-library__jest-dom": "6.0.0",
     "babel-preset-solid": "1.7.7",
     "commitizen": "4.3.0",
-    "husky": "8.0.3",
     "inquirer": "8.2.5",
     "jest": "28.1.3",
     "jest-environment-jsdom": "28.1.3",
-    "lint-staged": "14.0.1",
     "prettier": "4.0.0-alpha.8",
     "prettier-plugin-tailwindcss": "0.5.3",
     "rollup": "3.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,9 +58,6 @@ importers:
       commitizen:
         specifier: 4.3.0
         version: 4.3.0
-      husky:
-        specifier: 8.0.3
-        version: 8.0.3
       inquirer:
         specifier: 8.2.5
         version: 8.2.5
@@ -70,9 +67,6 @@ importers:
       jest-environment-jsdom:
         specifier: 28.1.3
         version: 28.1.3
-      lint-staged:
-        specifier: 14.0.1
-        version: 14.0.1
       prettier:
         specifier: 4.0.0-alpha.8
         version: 4.0.0-alpha.8
@@ -5364,16 +5358,6 @@ packages:
       type-fest: 0.21.3
     dev: true
 
-  /ansi-escapes@5.0.0:
-    resolution:
-      {
-        integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==,
-      }
-    engines: { node: ">=12" }
-    dependencies:
-      type-fest: 1.4.0
-    dev: true
-
   /ansi-purge@1.0.0:
     resolution:
       {
@@ -5387,14 +5371,6 @@ packages:
         integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
       }
     engines: { node: ">=8" }
-
-  /ansi-regex@6.0.1:
-    resolution:
-      {
-        integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==,
-      }
-    engines: { node: ">=12" }
-    dev: true
 
   /ansi-sequence-parser@1.1.1:
     resolution:
@@ -5427,14 +5403,6 @@ packages:
         integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==,
       }
     engines: { node: ">=10" }
-
-  /ansi-styles@6.2.1:
-    resolution:
-      {
-        integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
-      }
-    engines: { node: ">=12" }
-    dev: true
 
   /ansi-truncate@1.0.1:
     resolution:
@@ -6156,14 +6124,6 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  /chalk@5.3.0:
-    resolution:
-      {
-        integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==,
-      }
-    engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
-    dev: true
-
   /char-regex@1.0.2:
     resolution:
       {
@@ -6249,33 +6209,12 @@ packages:
       restore-cursor: 3.1.0
     dev: true
 
-  /cli-cursor@4.0.0:
-    resolution:
-      {
-        integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-    dependencies:
-      restore-cursor: 4.0.0
-    dev: true
-
   /cli-spinners@2.9.1:
     resolution:
       {
         integrity: sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==,
       }
     engines: { node: ">=6" }
-    dev: true
-
-  /cli-truncate@3.1.0:
-    resolution:
-      {
-        integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-    dependencies:
-      slice-ansi: 5.0.0
-      string-width: 5.1.2
     dev: true
 
   /cli-width@3.0.0:
@@ -6390,14 +6329,6 @@ packages:
       {
         integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==,
       }
-    dev: true
-
-  /commander@11.0.0:
-    resolution:
-      {
-        integrity: sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==,
-      }
-    engines: { node: ">=16" }
     dev: true
 
   /commander@2.20.3:
@@ -7078,13 +7009,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  /eastasianwidth@0.2.0:
-    resolution:
-      {
-        integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
-      }
-    dev: true
-
   /ee-first@1.1.1:
     resolution:
       {
@@ -7117,13 +7041,6 @@ packages:
       {
         integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
       }
-
-  /emoji-regex@9.2.2:
-    resolution:
-      {
-        integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
-      }
-    dev: true
 
   /encodeurl@1.0.2:
     resolution:
@@ -7774,13 +7691,6 @@ packages:
         integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
       }
     engines: { node: ">=0.10.0" }
-
-  /eventemitter3@5.0.1:
-    resolution:
-      {
-        integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==,
-      }
-    dev: true
 
   /execa@5.1.1:
     resolution:
@@ -8754,15 +8664,6 @@ packages:
       }
     engines: { node: ">=14.18.0" }
 
-  /husky@8.0.3:
-    resolution:
-      {
-        integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==,
-      }
-    engines: { node: ">=14" }
-    hasBin: true
-    dev: true
-
   /iconv-lite@0.4.24:
     resolution:
       {
@@ -9079,14 +8980,6 @@ packages:
         integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
       }
     engines: { node: ">=8" }
-
-  /is-fullwidth-code-point@4.0.0:
-    resolution:
-      {
-        integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==,
-      }
-    engines: { node: ">=12" }
-    dev: true
 
   /is-generator-fn@2.1.0:
     resolution:
@@ -10182,49 +10075,6 @@ packages:
       }
     dev: true
 
-  /lint-staged@14.0.1:
-    resolution:
-      {
-        integrity: sha512-Mw0cL6HXnHN1ag0mN/Dg4g6sr8uf8sn98w2Oc1ECtFto9tvRF7nkXGJRbx8gPlHyoR0pLyBr2lQHbWwmUHe1Sw==,
-      }
-    engines: { node: ^16.14.0 || >=18.0.0 }
-    hasBin: true
-    dependencies:
-      chalk: 5.3.0
-      commander: 11.0.0
-      debug: 4.3.4
-      execa: 7.2.0
-      lilconfig: 2.1.0
-      listr2: 6.6.1
-      micromatch: 4.0.5
-      pidtree: 0.6.0
-      string-argv: 0.3.2
-      yaml: 2.3.1
-    transitivePeerDependencies:
-      - enquirer
-      - supports-color
-    dev: true
-
-  /listr2@6.6.1:
-    resolution:
-      {
-        integrity: sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==,
-      }
-    engines: { node: ">=16.0.0" }
-    peerDependencies:
-      enquirer: ">= 2.3.0 < 3"
-    peerDependenciesMeta:
-      enquirer:
-        optional: true
-    dependencies:
-      cli-truncate: 3.1.0
-      colorette: 2.0.20
-      eventemitter3: 5.0.1
-      log-update: 5.0.1
-      rfdc: 1.3.0
-      wrap-ansi: 8.1.0
-    dev: true
-
   /load-tsconfig@0.2.5:
     resolution:
       {
@@ -10385,20 +10235,6 @@ packages:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-    dev: true
-
-  /log-update@5.0.1:
-    resolution:
-      {
-        integrity: sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-    dependencies:
-      ansi-escapes: 5.0.0
-      cli-cursor: 4.0.0
-      slice-ansi: 5.0.0
-      strip-ansi: 7.1.0
-      wrap-ansi: 8.1.0
     dev: true
 
   /longest-streak@3.1.0:
@@ -11900,15 +11736,6 @@ packages:
       }
     engines: { node: ">=8.6" }
 
-  /pidtree@0.6.0:
-    resolution:
-      {
-        integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==,
-      }
-    engines: { node: ">=0.10" }
-    hasBin: true
-    dev: true
-
   /pify@2.3.0:
     resolution:
       {
@@ -12656,30 +12483,12 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /restore-cursor@4.0.0:
-    resolution:
-      {
-        integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-    dev: true
-
   /reusify@1.0.4:
     resolution:
       {
         integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==,
       }
     engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
-
-  /rfdc@1.3.0:
-    resolution:
-      {
-        integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==,
-      }
-    dev: true
 
   /rimraf@3.0.2:
     resolution:
@@ -13093,17 +12902,6 @@ packages:
     engines: { node: ">=12" }
     dev: true
 
-  /slice-ansi@5.0.0:
-    resolution:
-      {
-        integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==,
-      }
-    engines: { node: ">=12" }
-    dependencies:
-      ansi-styles: 6.2.1
-      is-fullwidth-code-point: 4.0.0
-    dev: true
-
   /smartwrap@2.0.2:
     resolution:
       {
@@ -13490,14 +13288,6 @@ packages:
       }
     engines: { node: ">=10.0.0" }
 
-  /string-argv@0.3.2:
-    resolution:
-      {
-        integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==,
-      }
-    engines: { node: ">=0.6.19" }
-    dev: true
-
   /string-length@4.0.2:
     resolution:
       {
@@ -13519,18 +13309,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  /string-width@5.1.2:
-    resolution:
-      {
-        integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
-      }
-    engines: { node: ">=12" }
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
-    dev: true
 
   /string.prototype.trim@1.2.8:
     resolution:
@@ -13593,16 +13371,6 @@ packages:
     engines: { node: ">=8" }
     dependencies:
       ansi-regex: 5.0.1
-
-  /strip-ansi@7.1.0:
-    resolution:
-      {
-        integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==,
-      }
-    engines: { node: ">=12" }
-    dependencies:
-      ansi-regex: 6.0.1
-    dev: true
 
   /strip-bom@3.0.0:
     resolution:
@@ -15266,18 +15034,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  /wrap-ansi@8.1.0:
-    resolution:
-      {
-        integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
-      }
-    engines: { node: ">=12" }
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 5.1.2
-      strip-ansi: 7.1.0
-    dev: true
-
   /wrappy@1.0.2:
     resolution:
       {
@@ -15358,14 +15114,6 @@ packages:
       {
         integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==,
       }
-    dev: true
-
-  /yaml@2.3.1:
-    resolution:
-      {
-        integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==,
-      }
-    engines: { node: ">= 14" }
     dev: true
 
   /yaml@2.3.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,9 +82,6 @@ importers:
       solid-js:
         specifier: 1.7.11
         version: 1.7.11
-      sort-package-json:
-        specifier: 2.5.1
-        version: 2.5.1
       ts-jest:
         specifier: 28.0.8
         version: 28.0.8(@babel/core@7.22.10)(@jest/types@28.1.3)(esbuild@0.18.20)(jest@28.1.3)(typescript@4.9.5)
@@ -6897,28 +6894,12 @@ packages:
     engines: { node: ">=8" }
     dev: true
 
-  /detect-indent@7.0.1:
-    resolution:
-      {
-        integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==,
-      }
-    engines: { node: ">=12.20" }
-    dev: true
-
   /detect-newline@3.1.0:
     resolution:
       {
         integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==,
       }
     engines: { node: ">=8" }
-    dev: true
-
-  /detect-newline@4.0.1:
-    resolution:
-      {
-        integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
     dev: true
 
   /dettle@1.0.1:
@@ -8129,14 +8110,6 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
-  /get-stdin@9.0.0:
-    resolution:
-      {
-        integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==,
-      }
-    engines: { node: ">=12" }
-    dev: true
-
   /get-stream@6.0.1:
     resolution:
       {
@@ -8153,13 +8126,6 @@ packages:
     dependencies:
       call-bind: 1.0.5
       get-intrinsic: 1.2.1
-    dev: true
-
-  /git-hooks-list@3.1.0:
-    resolution:
-      {
-        integrity: sha512-LF8VeHeR7v+wAbXqfgRlTSX/1BJR9Q1vEMR8JAz1cEg6GX07+zyj3sAdDvYjj/xnlIfVuGgj4qBei1K3hKH+PA==,
-      }
     dev: true
 
   /git-raw-commits@2.0.11:
@@ -8310,20 +8276,6 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
-    dev: true
-
-  /globby@13.2.2:
-    resolution:
-      {
-        integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-    dependencies:
-      dir-glob: 3.0.1
-      fast-glob: 3.3.1
-      ignore: 5.2.4
-      merge2: 1.4.1
-      slash: 4.0.0
     dev: true
 
   /gopd@1.0.1:
@@ -12894,14 +12846,6 @@ packages:
     engines: { node: ">=8" }
     dev: true
 
-  /slash@4.0.0:
-    resolution:
-      {
-        integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==,
-      }
-    engines: { node: ">=12" }
-    dev: true
-
   /smartwrap@2.0.2:
     resolution:
       {
@@ -13085,29 +13029,6 @@ packages:
     engines: { node: ">=12" }
     dependencies:
       is-plain-obj: 4.1.0
-    dev: true
-
-  /sort-object-keys@1.1.3:
-    resolution:
-      {
-        integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==,
-      }
-    dev: true
-
-  /sort-package-json@2.5.1:
-    resolution:
-      {
-        integrity: sha512-vx/KoZxm8YNMUqdlw7SGTfqR5pqZ/sUfgOuRtDILiOy/3AvzhAibyUe2cY3OpLs3oRSow9up4yLVtQaM24rbDQ==,
-      }
-    hasBin: true
-    dependencies:
-      detect-indent: 7.0.1
-      detect-newline: 4.0.1
-      get-stdin: 9.0.0
-      git-hooks-list: 3.1.0
-      globby: 13.2.2
-      is-plain-obj: 4.1.0
-      sort-object-keys: 1.1.3
     dev: true
 
   /source-map-js@1.0.2:


### PR DESCRIPTION
Part of #318 

Remove git hooks as they slow down and sometime break development, or just don't work on some systems.

To remove hooks installed from earlier versions:
1. Delete folder `.git/hooks/`
2. Run `git config --unset core.hooksPath` 