### PR TITLE
fix(context-menu): add context.setAnchorRect call on pointer down

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Kobalte follows the [conventional commits](https://www.conventionalcommits.org/e
 - Build local version of all packages – `pnpm build:libs`.
 - Build local version of specific packages – `pnpm -F <package-name> build`.
 - To start docs – `pnpm dev:docs`.
-- To start playground – `pnpm dev:playground`.
+- To start playground – `pnpm dev:core`.
 
 ### Tests
 

--- a/packages/core/src/context-menu/context-menu-trigger.tsx
+++ b/packages/core/src/context-menu/context-menu-trigger.tsx
@@ -101,6 +101,7 @@ export function ContextMenuTrigger(props: ContextMenuTriggerProps) {
 		if (!local.disabled && isTouchOrPen(e)) {
 			// Clear the long press here in case there's multiple touch points.
 			clearLongPressTimeout();
+			context.setAnchorRect({ x: e.clientX, y: e.clientY });
 			longPressTimoutId = window.setTimeout(() => menuContext.open(false), 700);
 		}
 	};


### PR DESCRIPTION
Long pressing the menu context trigger was not positioning the context menu on iOS devices.

![IMG_428](https://github.com/kobaltedev/kobalte/assets/1901675/33dc5ce4-ff7c-448b-8edf-656d4f8c4bad)

The PR adds a context.setAnchorRect call on pointer down event listener to position the context menu on iOS devices.

![IMG_4305](https://github.com/kobaltedev/kobalte/assets/1901675/49a5db05-bf59-4cc4-b8b9-8c3b73c7f3c7)


fix #271