### PR TITLE
Improve number fields behavior when formatted with a unit

### DIFF
--- a/packages/core/src/number-field/number-field-root.tsx
+++ b/packages/core/src/number-field/number-field-root.tsx
@@ -203,8 +203,12 @@ export function NumberFieldRoot(props: NumberFieldRootProps) {
 
 	const isValidPartialValue = (value: string | number | undefined) =>
 		local.format && typeof value !== "number"
-			? numberParser().isValidPartialNumber(value ?? "", mergedProps.minValue, mergedProps.maxValue)
-			: !isNaN(Number(value));
+			? numberParser().isValidPartialNumber(
+					value ?? "",
+					mergedProps.minValue,
+					mergedProps.maxValue,
+			  )
+			: !Number.isNaN(Number(value));
 
 	const [value, setValue] = createControllableSignal({
 		value: () => local.value,
@@ -252,9 +256,9 @@ export function NumberFieldRoot(props: NumberFieldRootProps) {
 
 		const target = e.target as HTMLInputElement;
 		// cache the cursor position in case we need to update the input's value.
-		let cursorPosition = target.selectionStart;
+		const cursorPosition = target.selectionStart;
 
-		if(isValidPartialValue(target.value)) {
+		if (isValidPartialValue(target.value)) {
 			if (e.inputType !== "insertText" || isAllowedInput(e.data || "")) {
 				setValue(target.value);
 			}


### PR DESCRIPTION
The new `NumberField` component is awesome, but while using it with `style: unit` format options specified, I realized it's behavior diverges pretty significantly from the lovely behavior in in the react spectrum component it's based on. This PR brings it closer into line, though it's still not quite perfect.

To see the issue:
- create a NumberField
- specify the following format options:
- attempt to type into the field:
    -  a decimal number into the field
    - typos like alphabetical characters
    - anything into the unit segment

```typescript
const formatOptions = {
    minimumFractionDigits: 0,
    maximumFractionDigits: 1,
    style: "unit",
    unit: "second",
    unitDisplay: "long"
};
```

Expected behavior:  The NumberField should normalize the user's input into a valid format
Actual behavior: The displayed value is polluted until submission, at which point it'll do it's best to parse what's there and renormalize.

This PR confirms that the user's changes are still parsable before committing them, without getting in the way of deleting the contents of the field entirely. It generally makes the unit behave like ineditable text.

Note that this may be able to completely replace the `allowedInput` regex prop (and related machinery) which doesn't have an analog in the react-spectrum NumberField, but I didn't want to make that assumption without checking in first.