### PR TITLE
fix(combobox): close on select with `focus` trigger mode

### DIFF
--- a/packages/core/src/combobox/combobox-base.tsx
+++ b/packages/core/src/combobox/combobox-base.tsx
@@ -533,6 +533,7 @@ export function ComboboxBase<
 				// Prevents the combobox to close and reopen when the input is cleared.
 				if (disclosureState.isOpen() && selectedKeys.size > 0) {
 					close();
+					setTimeout(close);
 				}
 			}
 


### PR DESCRIPTION
fixes #387 