### PR TITLE
chore: strip license headers from build

### DIFF
--- a/packages/core/src/accordion/accordion-content.tsx
+++ b/packages/core/src/accordion/accordion-content.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/accordion/accordion-item.tsx
+++ b/packages/core/src/accordion/accordion-item.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/accordion/accordion-root.tsx
+++ b/packages/core/src/accordion/accordion-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/accordion/accordion-trigger.tsx
+++ b/packages/core/src/accordion/accordion-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/accordion/accordion.test.tsx
+++ b/packages/core/src/accordion/accordion.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/alert-dialog/alert-dialog.test.tsx
+++ b/packages/core/src/alert-dialog/alert-dialog.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/breadcrumbs/breadcrumbs-link.tsx
+++ b/packages/core/src/breadcrumbs/breadcrumbs-link.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/breadcrumbs/breadcrumbs-root.tsx
+++ b/packages/core/src/breadcrumbs/breadcrumbs-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/breadcrumbs/breadcrumbs.test.tsx
+++ b/packages/core/src/breadcrumbs/breadcrumbs.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/button/button-root.tsx
+++ b/packages/core/src/button/button-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/button/is-button.ts
+++ b/packages/core/src/button/is-button.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/checkbox/checkbox-input.tsx
+++ b/packages/core/src/checkbox/checkbox-input.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/checkbox/checkbox-root.tsx
+++ b/packages/core/src/checkbox/checkbox-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/checkbox/checkbox.test.tsx
+++ b/packages/core/src/checkbox/checkbox.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/collapsible/collapsible-content.tsx
+++ b/packages/core/src/collapsible/collapsible-content.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/collapsible/collapsible-root.tsx
+++ b/packages/core/src/collapsible/collapsible-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/collapsible/collapsible-trigger.tsx
+++ b/packages/core/src/collapsible/collapsible-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/collapsible/collapsible.test.tsx
+++ b/packages/core/src/collapsible/collapsible.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/color-mode/color-mode-context.tsx
+++ b/packages/core/src/color-mode/color-mode-context.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Original code by Chakra UI
  * MIT Licensed, Copyright (c) 2019 Segun Adebayo.
  *

--- a/packages/core/src/color-mode/color-mode-provider.tsx
+++ b/packages/core/src/color-mode/color-mode-provider.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Original code by Chakra UI
  * MIT Licensed, Copyright (c) 2019 Segun Adebayo.
  *

--- a/packages/core/src/color-mode/color-mode-script.tsx
+++ b/packages/core/src/color-mode/color-mode-script.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from chakra-ui.
  * MIT Licensed, Copyright (c) 2019 Segun Adebayo.
  *

--- a/packages/core/src/color-mode/storage-manager.ts
+++ b/packages/core/src/color-mode/storage-manager.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Original code by Chakra UI
  * MIT Licensed, Copyright (c) 2019 Segun Adebayo.
  *

--- a/packages/core/src/color-mode/types.ts
+++ b/packages/core/src/color-mode/types.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Original code by Chakra UI
  * MIT Licensed, Copyright (c) 2019 Segun Adebayo.
  *

--- a/packages/core/src/color-mode/utils.ts
+++ b/packages/core/src/color-mode/utils.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Original code by Chakra UI
  * MIT Licensed, Copyright (c) 2019 Segun Adebayo.
  *

--- a/packages/core/src/combobox/combobox-base.tsx
+++ b/packages/core/src/combobox/combobox-base.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/combobox/combobox-hidden-select.tsx
+++ b/packages/core/src/combobox/combobox-hidden-select.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/combobox/combobox-input.tsx
+++ b/packages/core/src/combobox/combobox-input.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/combobox/combobox-trigger.tsx
+++ b/packages/core/src/combobox/combobox-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/combobox/combobox.test.tsx
+++ b/packages/core/src/combobox/combobox.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/context-menu/context-menu-content.tsx
+++ b/packages/core/src/context-menu/context-menu-content.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/context-menu/context-menu-root.tsx
+++ b/packages/core/src/context-menu/context-menu-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/context-menu/context-menu-trigger.tsx
+++ b/packages/core/src/context-menu/context-menu-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/dialog/dialog-content.tsx
+++ b/packages/core/src/dialog/dialog-content.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/dialog/dialog-trigger.tsx
+++ b/packages/core/src/dialog/dialog-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/dialog/dialog.test.tsx
+++ b/packages/core/src/dialog/dialog.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/dismissable-layer/dismissable-layer.tsx
+++ b/packages/core/src/dismissable-layer/dismissable-layer.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/dismissable-layer/layer-stack.tsx
+++ b/packages/core/src/dismissable-layer/layer-stack.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/form-control/create-form-control.test.tsx
+++ b/packages/core/src/form-control/create-form-control.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/form-control/create-form-control.tsx
+++ b/packages/core/src/form-control/create-form-control.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/hover-card/hover-card-root.tsx
+++ b/packages/core/src/hover-card/hover-card-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/hover-card/hover-card-trigger.tsx
+++ b/packages/core/src/hover-card/hover-card-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/hover-card/utils.ts
+++ b/packages/core/src/hover-card/utils.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/i18n/create-collator.ts
+++ b/packages/core/src/i18n/create-collator.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/i18n/create-date-formatter.ts
+++ b/packages/core/src/i18n/create-date-formatter.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/i18n/create-default-locale.ts
+++ b/packages/core/src/i18n/create-default-locale.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/i18n/create-filter.ts
+++ b/packages/core/src/i18n/create-filter.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/i18n/create-number-formatter.ts
+++ b/packages/core/src/i18n/create-number-formatter.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/i18n/i18n-provider.tsx
+++ b/packages/core/src/i18n/i18n-provider.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/i18n/utils.ts
+++ b/packages/core/src/i18n/utils.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/image/image-fallback.tsx
+++ b/packages/core/src/image/image-fallback.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/image/image-img.tsx
+++ b/packages/core/src/image/image-img.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/image/image-root.tsx
+++ b/packages/core/src/image/image-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/image/image.test.tsx
+++ b/packages/core/src/image/image.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/image/types.ts
+++ b/packages/core/src/image/types.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/link/link-root.tsx
+++ b/packages/core/src/link/link-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/list/create-list-state.ts
+++ b/packages/core/src/list/create-list-state.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/list/create-selectable-list.ts
+++ b/packages/core/src/list/create-selectable-list.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/list/create-single-select-list-state.ts
+++ b/packages/core/src/list/create-single-select-list-state.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/list/list-collection.ts
+++ b/packages/core/src/list/list-collection.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/list/list-keyboard-delegate.ts
+++ b/packages/core/src/list/list-keyboard-delegate.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/listbox/listbox-item-description.tsx
+++ b/packages/core/src/listbox/listbox-item-description.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/listbox/listbox-item-label.tsx
+++ b/packages/core/src/listbox/listbox-item-label.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/listbox/listbox-item.tsx
+++ b/packages/core/src/listbox/listbox-item.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/listbox/listbox-root.tsx
+++ b/packages/core/src/listbox/listbox-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/listbox/listbox.test.tsx
+++ b/packages/core/src/listbox/listbox.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/live-announcer/live-announcer.tsx
+++ b/packages/core/src/live-announcer/live-announcer.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/menu/menu-content-base.tsx
+++ b/packages/core/src/menu/menu-content-base.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/menu/menu-group-label.tsx
+++ b/packages/core/src/menu/menu-group-label.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/menu/menu-group.tsx
+++ b/packages/core/src/menu/menu-group.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/menu/menu-item-base.tsx
+++ b/packages/core/src/menu/menu-item-base.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/menu/menu-item-description.tsx
+++ b/packages/core/src/menu/menu-item-description.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/menu/menu-item-label.tsx
+++ b/packages/core/src/menu/menu-item-label.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/menu/menu-radio-group.tsx
+++ b/packages/core/src/menu/menu-radio-group.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/menu/menu-sub-content.tsx
+++ b/packages/core/src/menu/menu-sub-content.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/menu/menu-sub-trigger.tsx
+++ b/packages/core/src/menu/menu-sub-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/menu/menu-trigger.tsx
+++ b/packages/core/src/menu/menu-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/menu/menu.tsx
+++ b/packages/core/src/menu/menu.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/menu/utils.ts
+++ b/packages/core/src/menu/utils.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/menubar/menubar-root.tsx
+++ b/packages/core/src/menubar/menubar-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/polymorphic/polymorphic.test.tsx
+++ b/packages/core/src/polymorphic/polymorphic.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/popover/popover-root.tsx
+++ b/packages/core/src/popover/popover-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/popover/popover-trigger.tsx
+++ b/packages/core/src/popover/popover-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/popper/popper-arrow.tsx
+++ b/packages/core/src/popper/popper-arrow.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/popper/popper-root.tsx
+++ b/packages/core/src/popper/popper-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/primitives/create-collection/create-collection.ts
+++ b/packages/core/src/primitives/create-collection/create-collection.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/primitives/create-collection/get-item-count.ts
+++ b/packages/core/src/primitives/create-collection/get-item-count.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/primitives/create-dom-collection/create-dom-collection.ts
+++ b/packages/core/src/primitives/create-dom-collection/create-dom-collection.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/primitives/create-dom-collection/utils.ts
+++ b/packages/core/src/primitives/create-dom-collection/utils.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/primitives/create-focus-scope/create-focus-scope.tsx
+++ b/packages/core/src/primitives/create-focus-scope/create-focus-scope.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/primitives/create-form-reset-listener/create-form-reset-listener.ts
+++ b/packages/core/src/primitives/create-form-reset-listener/create-form-reset-listener.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from zag.
  * MIT Licensed, Copyright (c) 2021 Chakra UI.
  *

--- a/packages/core/src/primitives/create-hide-outside/aria-hide-outside.test.tsx
+++ b/packages/core/src/primitives/create-hide-outside/aria-hide-outside.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/primitives/create-hide-outside/create-hide-outside.ts
+++ b/packages/core/src/primitives/create-hide-outside/create-hide-outside.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * This file is based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/primitives/create-interact-outside/create-interact-outside.ts
+++ b/packages/core/src/primitives/create-interact-outside/create-interact-outside.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/primitives/create-presence/create-presence.ts
+++ b/packages/core/src/primitives/create-presence/create-presence.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/primitives/create-tag-name/create-tag-name.test.tsx
+++ b/packages/core/src/primitives/create-tag-name/create-tag-name.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/primitives/create-tag-name/create-tag-name.ts
+++ b/packages/core/src/primitives/create-tag-name/create-tag-name.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/primitives/create-toggle-state/create-toggle-state.ts
+++ b/packages/core/src/primitives/create-toggle-state/create-toggle-state.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/primitives/create-transition/create-transition.ts
+++ b/packages/core/src/primitives/create-transition/create-transition.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from mantinedev.
  * MIT Licensed, Copyright (c) 2021 Vitaly Rtishchev.
  *

--- a/packages/core/src/primitives/create-transition/get-transition-styles.test.ts
+++ b/packages/core/src/primitives/create-transition/get-transition-styles.test.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from mantinedev.
  * MIT Licensed, Copyright (c) 2021 Vitaly Rtishchev.
  *

--- a/packages/core/src/primitives/create-transition/get-transition-styles.ts
+++ b/packages/core/src/primitives/create-transition/get-transition-styles.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from mantinedev.
  * MIT Licensed, Copyright (c) 2021 Vitaly Rtishchev.
  *

--- a/packages/core/src/primitives/create-transition/types.ts
+++ b/packages/core/src/primitives/create-transition/types.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from mantinedev.
  * MIT Licensed, Copyright (c) 2021 Vitaly Rtishchev.
  *

--- a/packages/core/src/progress/progress-root.tsx
+++ b/packages/core/src/progress/progress-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/progress/progress.test.tsx
+++ b/packages/core/src/progress/progress.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/radio-group/radio-group-item-input.tsx
+++ b/packages/core/src/radio-group/radio-group-item-input.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/radio-group/radio-group-item.tsx
+++ b/packages/core/src/radio-group/radio-group-item.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/radio-group/radio-group-root.tsx
+++ b/packages/core/src/radio-group/radio-group-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/radio-group/radio-group.test.tsx
+++ b/packages/core/src/radio-group/radio-group.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/select/hidden-select-base.tsx
+++ b/packages/core/src/select/hidden-select-base.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/select/select-base.tsx
+++ b/packages/core/src/select/select-base.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/select/select-hidden-select.tsx
+++ b/packages/core/src/select/select-hidden-select.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/select/select-trigger.tsx
+++ b/packages/core/src/select/select-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/select/select.test.tsx
+++ b/packages/core/src/select/select.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/selection/create-multiple-selection-state.ts
+++ b/packages/core/src/selection/create-multiple-selection-state.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/selection/create-selectable-collection.ts
+++ b/packages/core/src/selection/create-selectable-collection.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/selection/create-selectable-item.ts
+++ b/packages/core/src/selection/create-selectable-item.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/selection/create-type-select.ts
+++ b/packages/core/src/selection/create-type-select.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/selection/selection-manager.ts
+++ b/packages/core/src/selection/selection-manager.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/selection/types.ts
+++ b/packages/core/src/selection/types.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/selection/utils.ts
+++ b/packages/core/src/selection/utils.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/separator/separator-root.tsx
+++ b/packages/core/src/separator/separator-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/skeleton/skeleton-root.tsx
+++ b/packages/core/src/skeleton/skeleton-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from Mantine.
  * MIT Licensed, Copyright (c) 2021 Vitaly Rtishchev.
  *

--- a/packages/core/src/slider/create-slider-state.ts
+++ b/packages/core/src/slider/create-slider-state.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/slider/slider-root.tsx
+++ b/packages/core/src/slider/slider-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/slider/slider-thumb.tsx
+++ b/packages/core/src/slider/slider-thumb.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/spin-button/spin-button-root.tsx
+++ b/packages/core/src/spin-button/spin-button-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/spin-button/spin-button.test.tsx
+++ b/packages/core/src/spin-button/spin-button.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/switch/switch-input.tsx
+++ b/packages/core/src/switch/switch-input.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/switch/switch-root.tsx
+++ b/packages/core/src/switch/switch-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/switch/switch.test.tsx
+++ b/packages/core/src/switch/switch.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/tabs/tabs-content.tsx
+++ b/packages/core/src/tabs/tabs-content.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/tabs/tabs-indicator.tsx
+++ b/packages/core/src/tabs/tabs-indicator.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/tabs/tabs-keyboard-delegate.ts
+++ b/packages/core/src/tabs/tabs-keyboard-delegate.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/tabs/tabs-list.tsx
+++ b/packages/core/src/tabs/tabs-list.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/tabs/tabs-root.tsx
+++ b/packages/core/src/tabs/tabs-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/tabs/tabs-trigger.tsx
+++ b/packages/core/src/tabs/tabs-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/tabs/tabs.test.tsx
+++ b/packages/core/src/tabs/tabs.test.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/text-field/text-field-input.tsx
+++ b/packages/core/src/text-field/text-field-input.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/text-field/text-field-text-area.tsx
+++ b/packages/core/src/text-field/text-field-text-area.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/toast/toast-close-button.tsx
+++ b/packages/core/src/toast/toast-close-button.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/toast/toast-list.tsx
+++ b/packages/core/src/toast/toast-list.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/toast/toast-region.tsx
+++ b/packages/core/src/toast/toast-region.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/toast/toast-root.tsx
+++ b/packages/core/src/toast/toast-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/toast/toast.intl.ts
+++ b/packages/core/src/toast/toast.intl.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/core/src/toast/types.ts
+++ b/packages/core/src/toast/types.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/toggle-button/toggle-button-root.tsx
+++ b/packages/core/src/toggle-button/toggle-button-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/tooltip/tooltip-content.tsx
+++ b/packages/core/src/tooltip/tooltip-content.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from radix-ui-primitives.
  * MIT Licensed, Copyright (c) 2022 WorkOS.
  *

--- a/packages/core/src/tooltip/tooltip-root.tsx
+++ b/packages/core/src/tooltip/tooltip-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/tooltip/tooltip-trigger.tsx
+++ b/packages/core/src/tooltip/tooltip-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/core/src/tooltip/utils.ts
+++ b/packages/core/src/tooltip/utils.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/dates/calendar/calendar-grid-body-cell-trigger.tsx
+++ b/packages/dates/calendar/calendar-grid-body-cell-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/calendar-grid-body-cell.tsx
+++ b/packages/dates/calendar/calendar-grid-body-cell.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/calendar-grid-header-cell.tsx
+++ b/packages/dates/calendar/calendar-grid-header-cell.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/calendar-grid-header-row.tsx
+++ b/packages/dates/calendar/calendar-grid-header-row.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/calendar-grid-header.tsx
+++ b/packages/dates/calendar/calendar-grid-header.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/calendar-grid.tsx
+++ b/packages/dates/calendar/calendar-grid.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/calendar-heading.tsx
+++ b/packages/dates/calendar/calendar-heading.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/calendar-next-trigger.tsx
+++ b/packages/dates/calendar/calendar-next-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/calendar-prev-trigger.tsx
+++ b/packages/dates/calendar/calendar-prev-trigger.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/calendar-root.tsx
+++ b/packages/dates/calendar/calendar-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/types.ts
+++ b/packages/dates/calendar/types.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/calendar/utils.ts
+++ b/packages/dates/calendar/utils.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/date-picker/date-picker-control.tsx
+++ b/packages/dates/date-picker/date-picker-control.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/date-picker/date-picker-input.tsx
+++ b/packages/dates/date-picker/date-picker-input.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/date-picker/date-picker-root.tsx
+++ b/packages/dates/date-picker/date-picker-root.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/date-picker/date-picker-segment.tsx
+++ b/packages/dates/date-picker/date-picker-segment.tsx
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/date-picker/types.ts
+++ b/packages/dates/date-picker/types.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/dates/date-picker/utils.ts
+++ b/packages/dates/date-picker/utils.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from headlessui.
  * MIT Licensed, Copyright (c) 2020 Tailwind Labs.
  *

--- a/packages/utils/src/array.ts
+++ b/packages/utils/src/array.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/utils/src/assertion.ts
+++ b/packages/utils/src/assertion.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Original code by Chakra UI
  * MIT Licensed, Copyright (c) 2019 Segun Adebayo.
  *

--- a/packages/utils/src/create-global-listeners.ts
+++ b/packages/utils/src/create-global-listeners.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/utils/src/focus-manager.ts
+++ b/packages/utils/src/focus-manager.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/utils/src/focus-without-scrolling.ts
+++ b/packages/utils/src/focus-without-scrolling.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/utils/src/get-scroll-parent.ts
+++ b/packages/utils/src/get-scroll-parent.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/utils/src/is-virtual-event.ts
+++ b/packages/utils/src/is-virtual-event.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/utils/src/number.ts
+++ b/packages/utils/src/number.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/utils/src/platform.ts
+++ b/packages/utils/src/platform.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/utils/src/polygon.ts
+++ b/packages/utils/src/polygon.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *

--- a/packages/utils/src/run-after-transition.ts
+++ b/packages/utils/src/run-after-transition.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/utils/src/scroll-into-view.ts
+++ b/packages/utils/src/scroll-into-view.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from react-spectrum.
  * Apache License Version 2.0, Copyright 2020 Adobe.
  *

--- a/packages/utils/src/tabbable.ts
+++ b/packages/utils/src/tabbable.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Portions of this file are based on code from ariakit.
  * MIT Licensed, Copyright (c) Diego Haz.
  *


### PR DESCRIPTION
Remove license headers from build as they already exist in NOTICE.txt distributed with the package.