### PR TITLE
fix: include the source in the packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,8 @@
       "types": "./dist/*/index.d.ts",
       "solid": "./dist/*/index.jsx",
       "default": "./dist/*/index.js"
-    }
+    },
+    "./src/*": "./src/*"
   },
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -52,8 +53,10 @@
       ]
     }
   },
+  "source": "src/index.tsx",
   "files": [
     "dist",
+    "src",
     "NOTICE.txt"
   ],
   "scripts": {

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -31,13 +31,16 @@
         "default": "./dist/index.js"
       },
       "require": "./dist/index.cjs"
-    }
+    },
+    "./src/*": "./src/*"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "source": "src/index.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -40,8 +40,10 @@
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
+	"source": "src/index.ts",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"scripts": {
 		"build": "tsup",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,13 +35,16 @@
         "default": "./dist/index.js"
       },
       "require": "./dist/index.cjs"
-    }
+    },
+    "./src/*": "./src/*"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "source": "src/index.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/vanilla-extract/package.json
+++ b/packages/vanilla-extract/package.json
@@ -30,13 +30,16 @@
       "default": "./dist/index.mjs",
       "require": "./dist/index.js",
       "node": "./dist/index.js"
-    }
+    },
+    "./src/*": "./src/*"
   },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "source": "src/index.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
This has several benefits:
- Allows directly importing the source files, that could resolve the issues with server-side rendering with various build systems
- Can result in more optimized code as the source file is directly built by the build tool (better tree shaking or more modern syntax)
- Compatibility with new package registries such as JSR that prefer TypeScript over JavaScript
- In security conscious environments, the source files can be checked against GitHub and then used directly.