### PR TITLE
Update Polymorphic to override the "component" prop of Dynamic

### DIFF
--- a/packages/core/src/polymorphic/polymorphic.tsx
+++ b/packages/core/src/polymorphic/polymorphic.tsx
@@ -65,6 +65,6 @@ export function Polymorphic<RenderProps>(
 
 	return (
 		// @ts-ignore: Props are valid but not worth calculating
-		<Dynamic component={local.as} {...others} />
+		<Dynamic {...others} component={local.as} />
 	);
 }


### PR DESCRIPTION
It took me a while to find the culprit of why my component wasn't working and it was as simple as my "component" prop overriding the component prop passed to SolidJS' Dynamic component.

Either this, or we should pass the Dynamic component's props as the Polymorphic props in TypeScript.