### PR TITLE
Recalculate tab indicator styles on resize

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,9 +24,7 @@
 	},
 	"license": "MIT",
 	"author": "jer3m01 <jer3m01@jer3m01.com>",
-	"contributors": [
-		"Fabien Marie-Louise <fabienml.dev@gmail.com>"
-	],
+	"contributors": ["Fabien Marie-Louise <fabienml.dev@gmail.com>"],
 	"sideEffects": false,
 	"type": "module",
 	"exports": {
@@ -47,18 +45,11 @@
 	"types": "dist/index.d.ts",
 	"typesVersions": {
 		"*": {
-			"*": [
-				"./dist/*/index.d.ts",
-				"./dist/index.d.ts"
-			]
+			"*": ["./dist/*/index.d.ts", "./dist/index.d.ts"]
 		}
 	},
 	"source": "src/index.tsx",
-	"files": [
-		"dist",
-		"src",
-		"NOTICE.txt"
-	],
+	"files": ["dist", "src", "NOTICE.txt"],
 	"scripts": {
 		"build": "pnpm build:cp && pnpm build:tsup",
 		"build:cp": "cp ../../NOTICE.txt .",
@@ -75,11 +66,12 @@
 		"@internationalized/number": "^3.2.1",
 		"@kobalte/utils": "^0.9.0",
 		"@solid-primitives/props": "^3.1.8",
+		"@solid-primitives/resize-observer": "^2.0.26",
 		"solid-presence": "^0.1.6",
 		"solid-prevent-scroll": "^0.1.4"
 	},
 	"devDependencies": {
-		"@kobalte/tests": "^0.6.0",
+		"@kobalte/tests": "workspace:*",
 		"esbuild-plugin-solid": "^0.5.0",
 		"tsup": "7.2.0"
 	},

--- a/packages/core/src/tabs/tabs-indicator.tsx
+++ b/packages/core/src/tabs/tabs-indicator.tsx
@@ -17,6 +17,7 @@ import {
 
 import type { Orientation } from "@kobalte/utils";
 import { combineStyle } from "@solid-primitives/props";
+import { createResizeObserver } from "@solid-primitives/resize-observer";
 import { useLocale } from "../i18n";
 import {
 	type ElementOf,
@@ -113,6 +114,8 @@ export function TabsIndicator<T extends ValidComponent = "div">(
 			{ defer: true },
 		),
 	);
+
+	createResizeObserver(context.selectedTab, computeStyle);
 
 	return (
 		<Polymorphic<TabsIndicatorRenderProps>

--- a/packages/core/src/tabs/tabs-indicator.tsx
+++ b/packages/core/src/tabs/tabs-indicator.tsx
@@ -115,7 +115,28 @@ export function TabsIndicator<T extends ValidComponent = "div">(
 		),
 	);
 
-	createResizeObserver(context.selectedTab, computeStyle);
+	const [resizing, setResizing] = createSignal(false);
+
+	let timeout: NodeJS.Timeout | null = null;
+	let prevTarget: any = null;
+	createResizeObserver(context.selectedTab, (_, t) => {
+		if (prevTarget !== t) {
+			prevTarget = t;
+			return;
+		}
+
+		setResizing(true);
+
+		if (timeout) clearTimeout(timeout);
+
+		// gives the browser a chance to skip any animations that are disabled while resizing
+		timeout = setTimeout(() => {
+			timeout = null;
+			setResizing(false);
+		}, 1);
+
+		computeStyle();
+	});
 
 	return (
 		<Polymorphic<TabsIndicatorRenderProps>
@@ -123,6 +144,7 @@ export function TabsIndicator<T extends ValidComponent = "div">(
 			role="presentation"
 			style={combineStyle(style(), local.style)}
 			data-orientation={context.orientation()}
+			data-resizing={resizing()}
 			{...others}
 		/>
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       '@solid-primitives/props':
         specifier: ^3.1.8
         version: 3.1.11(solid-js@1.8.15)
+      '@solid-primitives/resize-observer':
+        specifier: ^2.0.26
+        version: 2.0.26(solid-js@1.8.15)
       solid-js:
         specifier: ^1.8.15
         version: 1.8.15
@@ -227,7 +230,7 @@ importers:
         version: 0.1.7(solid-js@1.8.15)
     devDependencies:
       '@kobalte/tests':
-        specifier: ^0.6.0
+        specifier: workspace:*
         version: link:../tests
       esbuild-plugin-solid:
         specifier: ^0.5.0
@@ -4307,6 +4310,18 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
+      '@solid-primitives/utils': 6.2.3(solid-js@1.8.15)
+      solid-js: 1.8.15
+    dev: false
+
+  /@solid-primitives/resize-observer@2.0.26(solid-js@1.8.15):
+    resolution: {integrity: sha512-KbPhwal6ML9OHeUTZszBbt6PYSMj89d4wVCLxlvDYL4U0+p+xlCEaqz6v9dkCwm/0Lb+Wed7W5T1dQZCP3JUUw==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/event-listener': 2.3.3(solid-js@1.8.15)
+      '@solid-primitives/rootless': 1.4.5(solid-js@1.8.15)
+      '@solid-primitives/static-store': 0.0.8(solid-js@1.8.15)
       '@solid-primitives/utils': 6.2.3(solid-js@1.8.15)
       solid-js: 1.8.15
     dev: false


### PR DESCRIPTION
The tab indicator currently doesn't resize if the tab trigger changes size. Adding a resize observer on the selected tab seems to be an easy fix.

https://github.com/user-attachments/assets/f3670102-3947-4fa1-9ed9-d0701c7a7e1b

https://github.com/user-attachments/assets/d9036b4d-4cfa-4fdc-9319-1e155e9afe60