### PR TITLE
Fix fixed items pagination

### DIFF
--- a/.changeset/nine-starfishes-join.md
+++ b/.changeset/nine-starfishes-join.md
@@ -1,0 +1,5 @@
+---
+"@kobalte/core": minor
+---
+
+fix pagination for fixed items with low count

--- a/.changeset/nine-starfishes-join.md
+++ b/.changeset/nine-starfishes-join.md
@@ -1,5 +1,0 @@
----
-"@kobalte/core": minor
----
-
-fix pagination for fixed items with low count

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,9 +24,7 @@
 	},
 	"license": "MIT",
 	"author": "jer3m01 <jer3m01@jer3m01.com>",
-	"contributors": [
-		"Fabien Marie-Louise <fabienml.dev@gmail.com>"
-	],
+	"contributors": ["Fabien Marie-Louise <fabienml.dev@gmail.com>"],
 	"sideEffects": false,
 	"type": "module",
 	"exports": {
@@ -47,18 +45,11 @@
 	"types": "dist/index.d.ts",
 	"typesVersions": {
 		"*": {
-			"*": [
-				"./dist/*/index.d.ts",
-				"./dist/index.d.ts"
-			]
+			"*": ["./dist/*/index.d.ts", "./dist/index.d.ts"]
 		}
 	},
 	"source": "src/index.tsx",
-	"files": [
-		"dist",
-		"src",
-		"NOTICE.txt"
-	],
+	"files": ["dist", "src", "NOTICE.txt"],
 	"scripts": {
 		"build": "pnpm build:cp && pnpm build:tsup",
 		"build:cp": "cp ../../NOTICE.txt .",

--- a/packages/core/src/pagination/pagination-items.tsx
+++ b/packages/core/src/pagination/pagination-items.tsx
@@ -1,11 +1,4 @@
-import {
-	For,
-	Show,
-	batch,
-	createEffect,
-	createSignal,
-	untrack,
-} from "solid-js";
+import { For, Show, createMemo } from "solid-js";
 
 import { usePaginationContext } from "./pagination-context";
 
@@ -14,86 +7,91 @@ export interface PaginationItemsProps {}
 export function PaginationItems(props: PaginationItemsProps) {
 	const context = usePaginationContext();
 
-	const [showFirst, setShowFirst] = createSignal(false);
-	const [showLast, setShowLast] = createSignal(false);
+	const items = createMemo(() => {
+		const { count, siblingCount, page, fixedItems } = context;
+		// render directly if count is so small that it does not make sense to render an ellipsis
+		// this is the case for if count is even -> 8, count is odd -> 7, each plus 2x siblingsCount
+		const renderItemsDirectly = context.fixedItems()
+			? count() < 2 * siblingCount() + 6
+			: count() < 2 * siblingCount() + 4; //(count() % 2 === 0 ? 6 : 5);
 
-	const [showFirstEllipsis, setShowFirstEllipsis] = createSignal(false);
-	const [showLastEllipsis, setShowLastEllipsis] = createSignal(false);
+		//skip the rest of the computation if we can render directly
+		if (renderItemsDirectly)
+			return {
+				renderItemsDirectly,
+			};
 
-	const [previousSiblingCount, setPreviousSiblingCount] = createSignal(0);
-	const [nextSiblingCount, setNextSiblingCount] = createSignal(0);
+		let showFirst = context.showFirst() && page() - 1 > siblingCount();
+		let showLast = context.showLast() && count() - page() > siblingCount();
 
-	createEffect(() => {
-		batch(() => {
-			setShowFirst(
-				context.showFirst() && context.page() - 1 > context.siblingCount(),
-			);
-			setShowLast(
-				context.showLast() &&
-					context.count() - context.page() > context.siblingCount(),
-			);
+		let showFirstEllipsis = page() - (context.showFirst() ? 2 : 1) > siblingCount();
+		let showLastEllipsis = count() - page() - (context.showLast() ? 1 : 0) > siblingCount();
 
-			setShowFirstEllipsis(
-				context.page() - (context.showFirst() ? 2 : 1) > context.siblingCount(),
-			);
-			setShowLastEllipsis(
-				context.count() - context.page() - (context.showLast() ? 1 : 0) >
-					context.siblingCount(),
-			);
+		let previousSiblingCount = Math.min(page() - 1, siblingCount());
+		let nextSiblingCount = Math.min(count() - page(), siblingCount());
 
-			setPreviousSiblingCount(
-				Math.min(context.page() - 1, context.siblingCount()),
-			);
-			setNextSiblingCount(
-				Math.min(context.count() - context.page(), context.siblingCount()),
-			);
+		if (fixedItems() !== false && !renderItemsDirectly) {
+			// ref to avoid wrong corretions
+			const nextSiblingCountRef = nextSiblingCount;
+			const previousSiblingCountRef = previousSiblingCount;
 
-			if (context.fixedItems() !== false) {
-				// Untrack to avoid recursion
-				untrack(() => {
-					// Add back the difference between the opposite side and the sibling count
-					setPreviousSiblingCount(
-						(prev) =>
-							prev + Math.max(context.siblingCount() - nextSiblingCount(), 0),
-					);
-					setNextSiblingCount(
-						(prev) =>
-							prev +
-							Math.max(context.siblingCount() - previousSiblingCount(), 0),
-					);
-				});
+			// Add back the difference between the opposite side and the sibling count
+			previousSiblingCount =
+				previousSiblingCount + Math.max(siblingCount() - nextSiblingCountRef, 0);
+			nextSiblingCount = nextSiblingCount + Math.max(siblingCount() - previousSiblingCountRef, 0);
 
-				if (!showFirst()) setNextSiblingCount((prev) => prev + 1);
-				if (!showLast()) setPreviousSiblingCount((prev) => prev + 1);
+			if (!showFirst) nextSiblingCount++;
+			if (!showLast) previousSiblingCount++;
 
-				// Check specifically if true and not "no-ellipsis"
-				if (context.fixedItems() === true) {
-					if (!showFirstEllipsis()) setNextSiblingCount((prev) => prev + 1);
-					if (!showLastEllipsis()) setPreviousSiblingCount((prev) => prev + 1);
-				}
+			// Check specifically if true and not "no-ellipsis"
+			if (fixedItems() === true) {
+				if (!showFirstEllipsis) nextSiblingCount++;
+				if (!showLastEllipsis) previousSiblingCount++;
 			}
-		});
+		}
+
+		return {
+			showFirst,
+			showLast,
+			showFirstEllipsis,
+			showLastEllipsis,
+			previousSiblingCount,
+			nextSiblingCount,
+			renderItemsDirectly,
+		};
 	});
 
 	return (
 		<>
-			<Show when={showFirst()}>{context.renderItem(1)}</Show>
+			<Show
+				when={items().renderItemsDirectly}
+				children={
+					<For each={[...Array(context.count()).keys()]}>
+						{page => <>{context.renderItem(page + 1)}</>}
+					</For>
+				}
+				fallback={
+					<>
+						<Show when={items().showFirst}>{context.renderItem(1)}</Show>
 
-			<Show when={showFirstEllipsis()}>{context.renderEllipsis()}</Show>
+						<Show when={items().showFirstEllipsis}>{context.renderEllipsis()}</Show>
 
-			<For each={[...Array(previousSiblingCount()).keys()].reverse()}>
-				{(offset) => <>{context.renderItem(context.page() - (offset + 1))}</>}
-			</For>
+						<For each={[...Array(items().previousSiblingCount).keys()].reverse()}>
+							{offset => <>{context.renderItem(context.page() - (offset + 1))}</>}
+						</For>
 
-			{context.renderItem(context.page())}
+						{context.renderItem(context.page())}
 
-			<For each={[...Array(nextSiblingCount()).keys()]}>
-				{(offset) => <>{context.renderItem(context.page() + (offset + 1))}</>}
-			</For>
+						<For each={[...Array(items().nextSiblingCount).keys()]}>
+							{offset => <>{context.renderItem(context.page() + (offset + 1))}</>}
+						</For>
 
-			<Show when={showLastEllipsis()}>{context.renderEllipsis()}</Show>
+						<Show when={items().showLastEllipsis}>{context.renderEllipsis()}</Show>
 
-			<Show when={showLast()}>{context.renderItem(context.count())}</Show>
+						<Show when={items().showLast}>{context.renderItem(context.count())}</Show>
+					</>
+				}
+			/>
 		</>
 	);
 }

--- a/packages/core/src/pagination/pagination-items.tsx
+++ b/packages/core/src/pagination/pagination-items.tsx
@@ -21,11 +21,13 @@ export function PaginationItems(props: PaginationItemsProps) {
 				renderItemsDirectly,
 			};
 
-		let showFirst = context.showFirst() && page() - 1 > siblingCount();
-		let showLast = context.showLast() && count() - page() > siblingCount();
+		const showFirst = context.showFirst() && page() - 1 > siblingCount();
+		const showLast = context.showLast() && count() - page() > siblingCount();
 
-		let showFirstEllipsis = page() - (context.showFirst() ? 2 : 1) > siblingCount();
-		let showLastEllipsis = count() - page() - (context.showLast() ? 1 : 0) > siblingCount();
+		const showFirstEllipsis =
+			page() - (context.showFirst() ? 2 : 1) > siblingCount();
+		const showLastEllipsis =
+			count() - page() - (context.showLast() ? 1 : 0) > siblingCount();
 
 		let previousSiblingCount = Math.min(page() - 1, siblingCount());
 		let nextSiblingCount = Math.min(count() - page(), siblingCount());
@@ -37,8 +39,11 @@ export function PaginationItems(props: PaginationItemsProps) {
 
 			// Add back the difference between the opposite side and the sibling count
 			previousSiblingCount =
-				previousSiblingCount + Math.max(siblingCount() - nextSiblingCountRef, 0);
-			nextSiblingCount = nextSiblingCount + Math.max(siblingCount() - previousSiblingCountRef, 0);
+				previousSiblingCount +
+				Math.max(siblingCount() - nextSiblingCountRef, 0);
+			nextSiblingCount =
+				nextSiblingCount +
+				Math.max(siblingCount() - previousSiblingCountRef, 0);
 
 			if (!showFirst) nextSiblingCount++;
 			if (!showLast) previousSiblingCount++;
@@ -65,33 +70,44 @@ export function PaginationItems(props: PaginationItemsProps) {
 		<>
 			<Show
 				when={items().renderItemsDirectly}
-				children={
-					<For each={[...Array(context.count()).keys()]}>
-						{page => <>{context.renderItem(page + 1)}</>}
-					</For>
-				}
 				fallback={
 					<>
 						<Show when={items().showFirst}>{context.renderItem(1)}</Show>
 
-						<Show when={items().showFirstEllipsis}>{context.renderEllipsis()}</Show>
+						<Show when={items().showFirstEllipsis}>
+							{context.renderEllipsis()}
+						</Show>
 
-						<For each={[...Array(items().previousSiblingCount).keys()].reverse()}>
-							{offset => <>{context.renderItem(context.page() - (offset + 1))}</>}
+						<For
+							each={[...Array(items().previousSiblingCount).keys()].reverse()}
+						>
+							{(offset) => (
+								<>{context.renderItem(context.page() - (offset + 1))}</>
+							)}
 						</For>
 
 						{context.renderItem(context.page())}
 
 						<For each={[...Array(items().nextSiblingCount).keys()]}>
-							{offset => <>{context.renderItem(context.page() + (offset + 1))}</>}
+							{(offset) => (
+								<>{context.renderItem(context.page() + (offset + 1))}</>
+							)}
 						</For>
 
-						<Show when={items().showLastEllipsis}>{context.renderEllipsis()}</Show>
+						<Show when={items().showLastEllipsis}>
+							{context.renderEllipsis()}
+						</Show>
 
-						<Show when={items().showLast}>{context.renderItem(context.count())}</Show>
+						<Show when={items().showLast}>
+							{context.renderItem(context.count())}
+						</Show>
 					</>
 				}
-			/>
+			>
+				<For each={[...Array(context.count()).keys()]}>
+					{(page) => <>{context.renderItem(page + 1)}</>}
+				</For>
+			</Show>
 		</>
 	);
 }

--- a/packages/core/src/pagination/pagination-root.tsx
+++ b/packages/core/src/pagination/pagination-root.tsx
@@ -121,7 +121,7 @@ export function PaginationRoot<T extends ValidComponent = "nav">(
 		isDisabled: () => local.disabled ?? false,
 		renderItem: (page) => local.itemComponent({ page }),
 		renderEllipsis: local.ellipsisComponent,
-		page: state[0] as Accessor<number>,
+		page: () => Math.min(state[0]() ?? 1, local.count),
 		setPage: state[1] as Setter<number>,
 	};
 


### PR DESCRIPTION
Added a fix for the case when paginations has fixedItems and the count is "small" which lead to

negative previousSibling pages
higher nextSibling pages than count
Added to render the pages directly if there's no need to render an ellipsis, because it would only replace one page.
All test still pass.

Side note: I converted the signals and createEffect to a single createMemo to avoid endless update loops.
Ryan Carniato once said in one of his talks that you should never set a signal from within createEffect and that it usually can be converted to a computed value (createMemo, createComputed,...) instead.

Feel free to reach out and discuss.
Spent a whole day, to figure it out. In the end it was so simple 😅

Closes: [Issue 461](https://github.com/kobaltedev/kobalte/issues/461)