### PR TITLE
bug(combobox) prevent combobox opening for input when triggerMode set to 'manual' (#462)

### DIFF
--- a/packages/core/src/combobox/combobox-base.tsx
+++ b/packages/core/src/combobox/combobox-base.tsx
@@ -596,6 +596,12 @@ export function ComboboxBase<
 		focusStrategy: FocusStrategy | boolean,
 		triggerMode?: ComboboxTriggerMode,
 	) => {
+
+		// If set to only open manually, ignore other triggers
+		if(local.triggerMode === 'manual' && triggerMode !== 'manual'){
+			return;
+		}
+
 		// Show all option if menu is manually opened.
 		const showAllOptions = setShowAllOptions(triggerMode === "manual");
 

--- a/packages/core/src/combobox/combobox-base.tsx
+++ b/packages/core/src/combobox/combobox-base.tsx
@@ -598,7 +598,7 @@ export function ComboboxBase<
 	) => {
 
 		// If set to only open manually, ignore other triggers
-		if(local.triggerMode === 'manual' && triggerMode !== 'manual'){
+		if (local.triggerMode === 'manual' && triggerMode !== 'manual') {
 			return;
 		}
 


### PR DESCRIPTION
Updates the combobox component to prevent opening the menu if the triggerMode has been set to manual, and the trigger source is not manual.

Other triggerModes are unaffected.

closes #462 