### PR TITLE
chore: prepare release `0.13.6`

### DIFF
--- a/.changeset/four-doors-sell.md
+++ b/.changeset/four-doors-sell.md
@@ -1,0 +1,10 @@
+---
+"@kobalte/core": patch
+"@kobalte/utils": patch
+---
+
+## v0.13.6 (August 27, 2024)
+
+**Bug fixes**
+
+- Update missing export from `@kobalte/utils` ([#477](https://github.com/kobaltedev/kobalte/pull/477))

--- a/apps/docs/src/VERSIONS.ts
+++ b/apps/docs/src/VERSIONS.ts
@@ -19,4 +19,4 @@ export const LATEST_CORE_CHANGELOG_URL = `/docs/changelog/${CORE_VERSIONS[0].rep
 	"-",
 )}`;
 
-export const LATEST_CORE_VERSION_NAME = "v0.13.5";
+export const LATEST_CORE_VERSION_NAME = "v0.13.6";

--- a/apps/docs/src/routes/docs/changelog/0-13-x.mdx
+++ b/apps/docs/src/routes/docs/changelog/0-13-x.mdx
@@ -1,5 +1,11 @@
 # v0.13.x
 
+## v0.13.6 (August 27, 2024)
+
+**Bug fixes**
+
+- Update missing export from `@kobalte/utils` ([#477](https://github.com/kobaltedev/kobalte/pull/477))
+
 ## v0.13.5 (August 27, 2024)
 
 **New features**


### PR DESCRIPTION
Update missing export from `@kobalte/utils`.

fixes #476 