### PR TITLE
fix: toggle group root options

### DIFF
--- a/packages/core/src/toggle-group/toggle-group-root.tsx
+++ b/packages/core/src/toggle-group/toggle-group-root.tsx
@@ -13,7 +13,7 @@ import {
 
 export interface ToggleGroupSingleOptions {
 	/** The controlled value of the toggle group. */
-	value?: string;
+	value?: string | null;
 
 	/**
 	 * The value of the select when initially rendered.

--- a/packages/core/src/toggle-group/toggle-group-root.tsx
+++ b/packages/core/src/toggle-group/toggle-group-root.tsx
@@ -22,7 +22,7 @@ export interface ToggleGroupSingleOptions {
 	defaultValue?: string;
 
 	/** Event handler called when the value changes. */
-	onChange?: (value: string) => void;
+	onChange?: (value: string | null) => void;
 
 	/** Whether the toggle group allow multiple selection. */
 	multiple?: false;


### PR DESCRIPTION
The value is possibly `null`, as the "no value" in the [implementation](https://github.com/ryoid/kobalte/blob/85f5bdc436c6a46ea81698ea098ff3fdfb9093cb/packages/core/src/toggle-group/toggle-group-root.tsx#L98-L99). This fixes the option to represent this behavior.