### PR TITLE
add `allowsCustomValue`

### DIFF
--- a/packages/core/src/combobox/combobox-context.tsx
+++ b/packages/core/src/combobox/combobox-context.tsx
@@ -1,4 +1,10 @@
-import { type Accessor, type JSX, createContext, useContext } from "solid-js";
+import {
+	type Accessor,
+	type JSX,
+	type Setter,
+	createContext,
+	useContext,
+} from "solid-js";
 
 import type { ListState } from "../list";
 import type { CollectionNode } from "../primitives";
@@ -28,6 +34,8 @@ export interface ComboboxContextValue {
 	activeDescendant: Accessor<string | undefined>;
 	inputValue: Accessor<string | undefined>;
 	triggerMode: Accessor<ComboboxTriggerMode>;
+	setOptions: Setter<unknown[]>;
+	allowsCustomValue: boolean;
 	controlRef: Accessor<HTMLElement | undefined>;
 	inputRef: Accessor<HTMLInputElement | undefined>;
 	triggerRef: Accessor<HTMLElement | undefined>;

--- a/packages/core/src/combobox/combobox-input.tsx
+++ b/packages/core/src/combobox/combobox-input.tsx
@@ -177,6 +177,11 @@ export function ComboboxInput<T extends ValidComponent = "input">(
 						selectionManager().select(focusedKey);
 					}
 				}
+				if (context.allowsCustomValue) {
+					const val = e.currentTarget.value;
+					context.setOptions((x) => [val, ...x]);
+					selectionManager().select(val);
+				}
 
 				break;
 			case "Tab":


### PR DESCRIPTION
Closes https://github.com/kobaltedev/kobalte/issues/491

Name inspired by https://react-spectrum.adobe.com/react-spectrum/ComboBox.html#custom-value

I'm seeking validation on the overall architecture of this feature. It requires at least one more `ComboboxBaseOptions`, perhaps named `customValueToOption`, that takes a string (`e.currentTarget.value`) and returns an `Option`.

Another option could be a `customValueValidator` since it's relatively easy for users to add an emptystring option, which probably isn't desirable.

I only tested using [this commit](https://github.com/AlexErrant/kobalte/commit/107d32be364cb1a697e6a790434d85da7c854b47), perhaps more rigorous testing is required - please LMK!