### PR TITLE
feat: new Meter component

### DIFF
--- a/apps/docs/src/examples/meter.module.css
+++ b/apps/docs/src/examples/meter.module.css
@@ -1,0 +1,38 @@
+.meter {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	width: 300px;
+}
+
+.meter__label-container {
+	display: flex;
+	justify-content: space-between;
+}
+
+.meter__label,
+.meter__value-label {
+	color: hsl(240 4% 16%);
+	font-size: 14px;
+}
+
+.meter__track {
+	height: 10px;
+	background-color: hsl(240 6% 90%);
+}
+
+.meter__fill {
+	background-color: hsl(200 98% 39%);
+	height: 100%;
+	width: var(--kb-meter-fill-width);
+	transition: width 250ms linear;
+}
+
+[data-kb-theme="dark"] .meter__label,
+[data-kb-theme="dark"] .meter__value-label {
+	color: hsl(0 100% 100% / 0.9);
+}
+
+[data-kb-theme="dark"] .meter__track {
+	background-color: hsl(240 5% 26%);
+}

--- a/apps/docs/src/examples/meter.tsx
+++ b/apps/docs/src/examples/meter.tsx
@@ -1,0 +1,51 @@
+import { Meter } from "@kobalte/core/meter";
+
+import style from "./meter.module.css";
+
+export function BasicExample() {
+	return (
+		<Meter value={80} class={style.meter}>
+			<div class={style["meter__label-container"]}>
+				<Meter.Label class={style.meter__label}>Batter Level:</Meter.Label>
+				<Meter.ValueLabel class={style["meter__value-label"]} />
+			</div>
+			<Meter.Track class={style.meter__track}>
+				<Meter.Fill class={style.meter__fill} />
+			</Meter.Track>
+		</Meter>
+	);
+}
+
+export function CustomValueScaleExample() {
+	return (
+		<Meter value={100} minValue={0} maxValue={250} class={style.meter}>
+			<div class={style["meter__label-container"]}>
+				<Meter.Label class={style.meter__label}>Disk Space Usage:</Meter.Label>
+				<Meter.ValueLabel class={style["meter__value-label"]} />
+			</div>
+			<Meter.Track class={style.meter__track}>
+				<Meter.Fill class={style.meter__fill} />
+			</Meter.Track>
+		</Meter>
+	);
+}
+
+export function CustomValueLabelExample() {
+	return (
+		<Meter
+			value={3}
+			minValue={0}
+			maxValue={10}
+			getValueLabel={({ value, max }) => `${value} of ${max} tasks completed`}
+			class={style.meter}
+		>
+			<div class={style["meter__label-container"]}>
+				<Meter.Label class={style.meter__label}>Processing...</Meter.Label>
+				<Meter.ValueLabel class={style["meter__value-label"]} />
+			</div>
+			<Meter.Track class={style.meter__track}>
+				<Meter.Fill class={style.meter__fill} />
+			</Meter.Track>
+		</Meter>
+	);
+}

--- a/apps/docs/src/routes/docs/core.tsx
+++ b/apps/docs/src/routes/docs/core.tsx
@@ -100,6 +100,7 @@ const CORE_NAV_SECTIONS: NavSection[] = [
 			{
 				title: "Meter",
 				href: "/docs/core/components/meter",
+				status: "new",
 			},
 			{
 				title: "Navigation Menu",

--- a/apps/docs/src/routes/docs/core.tsx
+++ b/apps/docs/src/routes/docs/core.tsx
@@ -98,6 +98,10 @@ const CORE_NAV_SECTIONS: NavSection[] = [
 				href: "/docs/core/components/menubar",
 			},
 			{
+				title: "Meter",
+				href: "/docs/core/components/meter",
+			},
+			{
 				title: "Navigation Menu",
 				href: "/docs/core/components/navigation-menu",
 				status: "new",

--- a/apps/docs/src/routes/docs/core/components/meter.mdx
+++ b/apps/docs/src/routes/docs/core/components/meter.mdx
@@ -1,0 +1,197 @@
+import { Preview, TabsSnippets } from "../../../../components";
+import {
+	BasicExample,
+	CustomValueLabelExample,
+	CustomValueScaleExample,
+} from "../../../../examples/meter";
+
+# Meter
+
+Displays numeric value that varies within a defined range
+
+## Import
+
+```ts
+import { Meter } from "@kobalte/core/meter";
+// or
+import { Root, Label, ... } from "@kobalte/core/meter";
+// or (deprecated)
+import { Meter } from "@kobalte/core";
+```
+
+## Features
+
+- Exposed to assistive technology as a meter via ARIA.
+- Labeling support for accessibility.
+- Internationalized number formatting as a percentage or value.
+
+## Anatomy
+
+The meter consists of:
+
+- **Meter:** The root container for a meter.
+- **Meter.Label:** An accessible label that gives the user information on the meter.
+- **Meter.ValueLabel:** The accessible label text representing the current value in a human-readable format.
+- **Meter.Track:** The component that visually represents the meter track.
+- **Meter.Fill:** The component that visually represents the meter value.
+
+```tsx
+<Meter>
+	<Meter.Label />
+	<Meter.ValueLabel />
+	<Meter.Track>
+		<Meter.Fill />
+	</Meter.Track>
+</Meter>
+```
+
+## Example
+
+<Preview>
+	<BasicExample />
+</Preview>
+
+<TabsSnippets>
+  <TabsSnippets.List>
+    <TabsSnippets.Trigger value="index.tsx">index.tsx</TabsSnippets.Trigger>
+    <TabsSnippets.Trigger value="style.css">style.css</TabsSnippets.Trigger>
+  </TabsSnippets.List>
+  {/* <!-- prettier-ignore-start -->*/}
+  <TabsSnippets.Content value="index.tsx">
+    ```tsx
+		import { Meter } from "@kobalte/core/meter";
+    import "./style.css";
+
+    function App() {
+      return (
+        <Meter value={80} class="meter">
+          <div class="meter__label-container">
+            <Meter.Label class="meter__label">Battery Level:</Meter.Label>
+            <Meter.ValueLabel class="meter__value-label" />
+          </div>
+          <Meter.Track class="meter__track">
+            <Meter.Fill class="meter__fill" />
+          </Meter.Track>
+        </Meter>
+      );
+    }
+    ```
+
+  </TabsSnippets.Content>
+  <TabsSnippets.Content value="style.css">
+    ```css
+    .meter {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      width: 300px;
+    }
+
+    .meter__label-container {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .meter__label,
+    .meter__value-label {
+      color: hsl(240 4% 16%);
+      font-size: 14px;
+    }
+
+    .meter__track {
+      height: 10px;
+      background-color: hsl(240 6% 90%);
+    }
+
+    .meter__fill {
+      background-color: hsl(200 98% 39%);
+      height: 100%;
+      width: var(--kb-meter-fill-width);
+      transition: width 250ms linear;
+    }
+
+    ```
+
+  </TabsSnippets.Content>
+  {/* <!-- prettier-ignore-end -->*/}
+</TabsSnippets>
+
+## Usage
+
+### Custom value scale
+
+By default, the `value` prop represents the current value of meter, as the minimum and maximum values default to 0 and 100, respectively. Alternatively, a different scale can be used by setting the `minValue` and `maxValue` props.
+
+<Preview>
+	<CustomValueScaleExample />
+</Preview>
+
+```tsx {0}
+<Meter value={100} minValue={0} maxValue={250} class="meter">
+	<div class="meter__label-container">
+		<Meter.Label class="meter__label">Disk Space Usage:</Meter.Label>
+		<Meter.ValueLabel class="meter__value-label" />
+	</div>
+	<Meter.Track class="meter__track">
+		<Meter.Fill class="meter__fill" />
+	</Meter.Track>
+</Meter>
+```
+
+### Custom value label
+
+The `getValueLabel` prop allows the formatted value used in `Meter.ValueLabel` and ARIA to be replaced with a custom string. It receives the current value, min and max values as parameters.
+
+<Preview>
+	<CustomValueLabelExample />
+</Preview>
+
+```tsx {4}
+<Meter
+	value={3}
+	minValue={0}
+	maxValue={10}
+	getValueLabel={({ value, max }) => `${value} of ${max} tasks completed`}
+	class="meter"
+>
+	<div class="meter__label-container">
+		<Meter.Label class="meter__label">Processing...</Meter.Label>
+		<Meter.ValueLabel class="meter__value-label" />
+	</div>
+	<Meter.Track class="meter__track">
+		<Meter.Fill class="meter__fill" />
+	</Meter.Track>
+</Meter>
+```
+
+### Meter fill width
+
+We expose a CSS custom property `--kb-meter-fill-width` which corresponds to the percentage of meterion (ex: 80%). If you are building a linear meter, you can use it to set the width of the `Meter.Fill` component in CSS.
+
+## API Reference
+
+### Meter
+
+`Meter` is equivalent to the `Root` import from `@kobalte/core/meter` (and deprecated `Meter.Root`).
+
+| Prop          | Description                                                                                                                                                                                                                                                    |
+| :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| value         | `number` <br/> The meter value.                                                                                                                                                                                                                                |
+| minValue      | `number` <br/> The minimum meter value.                                                                                                                                                                                                                        |
+| maxValue      | `number` <br/> The maximum meter value.                                                                                                                                                                                                                        |
+| getValueLabel | `(params: { value: number; min: number; max: number }) => string` <br/> A function to get the accessible label text representing the current value in a human-readable format. If not provided, the value label will be read as a percentage of the max value. |
+
+| Data attribute | Description |
+| :------------- | :---------- |
+
+`Meter.Label`, `Meter.ValueLabel`, `Meter.Track` and `Meter.Fill` shares the same data-attributes.
+
+## Rendered elements
+
+| Component          | Default rendered element |
+| :----------------- | :----------------------- |
+| `Meter`            | `div`                    |
+| `Meter.Label`      | `span`                   |
+| `Meter.ValueLabel` | `div`                    |
+| `Meter.Track`      | `div`                    |
+| `Meter.Fill`       | `div`                    |

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -28,6 +28,7 @@ export * as Image from "./image";
 export * as Link from "./link";
 export * as Listbox from "./listbox";
 export * as Menubar from "./menubar";
+export * as Meter from "./meter";
 export * as NumberField from "./number-field";
 export * as Pagination from "./pagination";
 export * as Popover from "./popover";

--- a/packages/core/src/meter/index.tsx
+++ b/packages/core/src/meter/index.tsx
@@ -1,0 +1,66 @@
+import {
+	MeterFill as Fill,
+	type MeterFillCommonProps,
+	type MeterFillOptions,
+	type MeterFillProps,
+	type MeterFillRenderProps,
+} from "./meter-fill";
+import {
+	MeterLabel as Label,
+	type MeterLabelCommonProps,
+	type MeterLabelOptions,
+	type MeterLabelProps,
+	type MeterLabelRenderProps,
+} from "./meter-label";
+import {
+	type MeterRootCommonProps,
+	type MeterRootOptions,
+	type MeterRootProps,
+	type MeterRootRenderProps,
+	MeterRoot as Root,
+} from "./meter-root";
+import {
+	type MeterTrackCommonProps,
+	type MeterTrackOptions,
+	type MeterTrackProps,
+	type MeterTrackRenderProps,
+	MeterTrack as Track,
+} from "./meter-track";
+import {
+	type MeterValueLabelCommonProps,
+	type MeterValueLabelOptions,
+	type MeterValueLabelProps,
+	type MeterValueLabelRenderProps,
+	MeterValueLabel as ValueLabel,
+} from "./meter-value-label";
+
+export type {
+	MeterFillOptions,
+	MeterFillCommonProps,
+	MeterFillRenderProps,
+	MeterFillProps,
+	MeterLabelOptions,
+	MeterLabelCommonProps,
+	MeterLabelRenderProps,
+	MeterLabelProps,
+	MeterRootOptions,
+	MeterRootCommonProps,
+	MeterRootRenderProps,
+	MeterRootProps,
+	MeterTrackOptions,
+	MeterTrackCommonProps,
+	MeterTrackRenderProps,
+	MeterTrackProps,
+	MeterValueLabelOptions,
+	MeterValueLabelCommonProps,
+	MeterValueLabelRenderProps,
+	MeterValueLabelProps,
+};
+export { Fill, Label, Root, Track, ValueLabel };
+
+export const Meter = Object.assign(Root, {
+	Fill,
+	Label,
+	Track,
+	ValueLabel,
+});

--- a/packages/core/src/meter/meter-context.tsx
+++ b/packages/core/src/meter/meter-context.tsx
@@ -1,0 +1,28 @@
+import { type Accessor, createContext, useContext } from "solid-js";
+
+export interface MeterDataSet {}
+
+export interface MeterContextValue {
+	dataset: Accessor<MeterDataSet>;
+	value: Accessor<number>;
+	valuePercent: Accessor<number>;
+	valueLabel: Accessor<string | undefined>;
+	meterFillWidth: Accessor<string | undefined>;
+	labelId: Accessor<string | undefined>;
+	generateId: (part: string) => string;
+	registerLabelId: (id: string) => () => void;
+}
+
+export const MeterContext = createContext<MeterContextValue>();
+
+export function useMeterContext() {
+	const context = useContext(MeterContext);
+
+	if (context === undefined) {
+		throw new Error(
+			"[kobalte]: `useMeterContext` must be used within a `Meter.Root` component",
+		);
+	}
+
+	return context;
+}

--- a/packages/core/src/meter/meter-fill.tsx
+++ b/packages/core/src/meter/meter-fill.tsx
@@ -1,0 +1,49 @@
+import { type JSX, type ValidComponent, splitProps } from "solid-js";
+
+import { combineStyle } from "@solid-primitives/props";
+import {
+	type ElementOf,
+	Polymorphic,
+	type PolymorphicProps,
+} from "../polymorphic";
+import { type MeterDataSet, useMeterContext } from "./meter-context";
+
+export interface MeterFillOptions {}
+
+export interface MeterFillCommonProps<T extends HTMLElement = HTMLElement> {
+	style?: JSX.CSSProperties | string;
+}
+
+export interface MeterFillRenderProps
+	extends MeterFillCommonProps,
+		MeterDataSet {}
+
+export type MeterFillProps<
+	T extends ValidComponent | HTMLElement = HTMLElement,
+> = MeterFillOptions & Partial<MeterFillCommonProps<ElementOf<T>>>;
+
+/**
+ * The component that visually represents the meter value.
+ * Used to visually show the fill of `Meter.Track`.
+ */
+export function MeterFill<T extends ValidComponent = "div">(
+	props: PolymorphicProps<T, MeterFillProps<T>>,
+) {
+	const context = useMeterContext();
+
+	const [local, others] = splitProps(props as MeterFillProps, ["style"]);
+
+	return (
+		<Polymorphic<MeterFillRenderProps>
+			as="div"
+			style={combineStyle(
+				{
+					"--kb-meter-fill-width": context.meterFillWidth(),
+				},
+				local.style,
+			)}
+			{...context.dataset()}
+			{...others}
+		/>
+	);
+}

--- a/packages/core/src/meter/meter-label.tsx
+++ b/packages/core/src/meter/meter-label.tsx
@@ -1,0 +1,57 @@
+import { mergeDefaultProps } from "@kobalte/utils";
+import {
+	type ValidComponent,
+	createEffect,
+	onCleanup,
+	splitProps,
+} from "solid-js";
+
+import {
+	type ElementOf,
+	Polymorphic,
+	type PolymorphicProps,
+} from "../polymorphic";
+import { type MeterDataSet, useMeterContext } from "./meter-context";
+
+export interface MeterLabelOptions {}
+
+export interface MeterLabelCommonProps<T extends HTMLElement = HTMLElement> {
+	id: string;
+}
+
+export interface MeterLabelRenderProps
+	extends MeterLabelCommonProps,
+		MeterDataSet {}
+
+export type MeterLabelProps<
+	T extends ValidComponent | HTMLElement = HTMLElement,
+> = MeterLabelOptions & Partial<MeterLabelCommonProps<ElementOf<T>>>;
+
+/**
+ * An accessible label that gives the user information on the meter.
+ */
+export function MeterLabel<T extends ValidComponent = "span">(
+	props: PolymorphicProps<T, MeterLabelProps<T>>,
+) {
+	const context = useMeterContext();
+
+	const mergedProps = mergeDefaultProps(
+		{
+			id: context.generateId("label"),
+		},
+		props as MeterLabelProps,
+	);
+
+	const [local, others] = splitProps(mergedProps, ["id"]);
+
+	createEffect(() => onCleanup(context.registerLabelId(local.id)));
+
+	return (
+		<Polymorphic<MeterLabelRenderProps>
+			as="span"
+			id={local.id}
+			{...context.dataset()}
+			{...others}
+		/>
+	);
+}

--- a/packages/core/src/meter/meter-root.tsx
+++ b/packages/core/src/meter/meter-root.tsx
@@ -1,0 +1,136 @@
+/*
+ * Portions of this file are based on code from react-spectrum.
+ * Apache License Version 2.0, Copyright 2020 Adobe.
+ *
+ * Credits to the React Spectrum team:
+ * https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/meter/src/useMeter.ts
+ */
+
+import { clamp, createGenerateId, mergeDefaultProps } from "@kobalte/utils";
+import {
+	type Accessor,
+	type ValidComponent,
+	createMemo,
+	createSignal,
+	createUniqueId,
+	splitProps,
+} from "solid-js";
+
+import { createNumberFormatter } from "../i18n";
+import {
+	type ElementOf,
+	Polymorphic,
+	type PolymorphicProps,
+} from "../polymorphic";
+import { createRegisterId } from "../primitives";
+import type { ProgressRootOptions } from "../progress";
+import {
+	MeterContext,
+	type MeterContextValue,
+	type MeterDataSet,
+} from "./meter-context";
+
+export interface MeterRootOptions
+	extends Omit<ProgressRootOptions, "indeterminate"> {}
+
+export interface MeterRootCommonProps<T extends HTMLElement = HTMLElement> {
+	id: string;
+}
+
+export interface MeterRootRenderProps
+	extends MeterRootCommonProps,
+		MeterDataSet {
+	role: "meter";
+	"aria-valuenow": number | undefined;
+	"aria-valuemin": number;
+	"aria-valuemax": number;
+	"aria-valuetext": string | undefined;
+	"aria-labelledby": string | undefined;
+}
+
+export type MeterRootProps<
+	T extends ValidComponent | HTMLElement = HTMLElement,
+> = MeterRootOptions & Partial<MeterRootCommonProps<ElementOf<T>>>;
+
+/**
+ * Meter displays numeric value that varies within a defined range.
+ */
+export function MeterRoot<T extends ValidComponent = "div">(
+	props: PolymorphicProps<T, MeterRootProps<T>>,
+) {
+	const defaultId = `meter-${createUniqueId()}`;
+
+	const mergedProps = mergeDefaultProps(
+		{
+			id: defaultId,
+			value: 0,
+			minValue: 0,
+			maxValue: 100,
+		},
+		props as MeterRootProps,
+	);
+
+	const [local, others] = splitProps(mergedProps, [
+		"value",
+		"minValue",
+		"maxValue",
+		"getValueLabel",
+	]);
+
+	const [labelId, setLabelId] = createSignal<string>();
+
+	const defaultFormatter = createNumberFormatter(() => ({ style: "percent" }));
+
+	const value = () => {
+		return clamp(local.value!, local.minValue!, local.maxValue!);
+	};
+
+	const valuePercent = () => {
+		return (value() - local.minValue!) / (local.maxValue! - local.minValue!);
+	};
+
+	const valueLabel = () => {
+		if (local.getValueLabel) {
+			return local.getValueLabel({
+				value: value(),
+				min: local.minValue!,
+				max: local.maxValue!,
+			});
+		}
+
+		return defaultFormatter().format(valuePercent());
+	};
+
+	const meterFillWidth = () => {
+		return `${Math.round(valuePercent() * 100)}%`;
+	};
+
+	const dataset: Accessor<MeterDataSet> = createMemo(() => {
+		return {};
+	});
+	const context: MeterContextValue = {
+		dataset,
+		value,
+		valuePercent,
+		valueLabel,
+		labelId,
+		meterFillWidth,
+		generateId: createGenerateId(() => others.id!),
+		registerLabelId: createRegisterId(setLabelId),
+	};
+
+	return (
+		<MeterContext.Provider value={context}>
+			<Polymorphic<MeterRootRenderProps>
+				as="div"
+				role="meter"
+				aria-valuenow={value()}
+				aria-valuemin={local.minValue}
+				aria-valuemax={local.maxValue}
+				aria-valuetext={valueLabel()}
+				aria-labelledby={labelId()}
+				{...others}
+			/>
+		</MeterContext.Provider>
+	);
+}

--- a/packages/core/src/meter/meter-root.tsx
+++ b/packages/core/src/meter/meter-root.tsx
@@ -23,15 +23,42 @@ import {
 	type PolymorphicProps,
 } from "../polymorphic";
 import { createRegisterId } from "../primitives";
-import type { ProgressRootOptions } from "../progress";
 import {
 	MeterContext,
 	type MeterContextValue,
 	type MeterDataSet,
 } from "./meter-context";
 
-export interface MeterRootOptions
-	extends Omit<ProgressRootOptions, "indeterminate"> {}
+interface GetValueLabelParams {
+	value: number;
+	min: number;
+	max: number;
+}
+export interface MeterRootOptions {
+	/**
+	 * The meter value.
+	 * @default 0
+	 */
+	value?: number;
+
+	/**
+	 * The minimum meter value.
+	 * @default 0
+	 */
+	minValue?: number;
+
+	/**
+	 * The maximum meter value.
+	 * @default 100
+	 */
+	maxValue?: number;
+
+	/**
+	 * A function to get the accessible label text representing the current value in a human-readable format.
+	 * If not provided, the value label will be read as a percentage of the max value.
+	 */
+	getValueLabel?: (params: GetValueLabelParams) => string;
+}
 
 export interface MeterRootCommonProps<T extends HTMLElement = HTMLElement> {
 	id: string;

--- a/packages/core/src/meter/meter-root.tsx
+++ b/packages/core/src/meter/meter-root.tsx
@@ -62,18 +62,17 @@ export interface MeterRootOptions {
 
 export interface MeterRootCommonProps<T extends HTMLElement = HTMLElement> {
 	id: string;
-}
-
-export interface MeterRootRenderProps
-	extends MeterRootCommonProps,
-		MeterDataSet {
-	role: "meter";
+	role: string;
 	"aria-valuenow": number | undefined;
 	"aria-valuemin": number;
 	"aria-valuemax": number;
 	"aria-valuetext": string | undefined;
 	"aria-labelledby": string | undefined;
 }
+
+export interface MeterRootRenderProps
+	extends MeterRootCommonProps,
+		MeterDataSet {}
 
 export type MeterRootProps<
 	T extends ValidComponent | HTMLElement = HTMLElement,
@@ -93,6 +92,8 @@ export function MeterRoot<T extends ValidComponent = "div">(
 			value: 0,
 			minValue: 0,
 			maxValue: 100,
+			role: "meter",
+			indeterminate: false,
 		},
 		props as MeterRootProps,
 	);
@@ -102,6 +103,13 @@ export function MeterRoot<T extends ValidComponent = "div">(
 		"minValue",
 		"maxValue",
 		"getValueLabel",
+		"role",
+		"aria-valuetext",
+		"aria-labelledby",
+		"aria-valuemax",
+		"aria-valuemin",
+		"aria-valuenow",
+		"indeterminate",
 	]);
 
 	const [labelId, setLabelId] = createSignal<string>();
@@ -117,6 +125,9 @@ export function MeterRoot<T extends ValidComponent = "div">(
 	};
 
 	const valueLabel = () => {
+		if (local.indeterminate) {
+			return undefined;
+		}
 		if (local.getValueLabel) {
 			return local.getValueLabel({
 				value: value(),
@@ -150,12 +161,13 @@ export function MeterRoot<T extends ValidComponent = "div">(
 		<MeterContext.Provider value={context}>
 			<Polymorphic<MeterRootRenderProps>
 				as="div"
-				role="meter"
-				aria-valuenow={value()}
+				role={local.role || "meter"}
+				aria-valuenow={local.indeterminate ? undefined : value()}
 				aria-valuemin={local.minValue}
 				aria-valuemax={local.maxValue}
 				aria-valuetext={valueLabel()}
 				aria-labelledby={labelId()}
+				{...dataset()}
 				{...others}
 			/>
 		</MeterContext.Provider>

--- a/packages/core/src/meter/meter-track.tsx
+++ b/packages/core/src/meter/meter-track.tsx
@@ -1,0 +1,37 @@
+import type { ValidComponent } from "solid-js";
+import {
+	type ElementOf,
+	Polymorphic,
+	type PolymorphicProps,
+} from "../polymorphic";
+import { type MeterDataSet, useMeterContext } from "./meter-context";
+
+export interface MeterTrackOptions {}
+
+export interface MeterTrackCommonProps<T extends HTMLElement = HTMLElement> {}
+
+export interface MeterTrackRenderProps
+	extends MeterTrackCommonProps,
+		MeterDataSet {}
+
+export type MeterTrackProps<
+	T extends ValidComponent | HTMLElement = HTMLElement,
+> = MeterTrackOptions & Partial<MeterTrackCommonProps<ElementOf<T>>>;
+
+/**
+ * The component that visually represents the meter track.
+ * Act as a container for `Meter.Fill`.
+ */
+export function MeterTrack<T extends ValidComponent = "div">(
+	props: PolymorphicProps<T, MeterTrackProps<T>>,
+) {
+	const context = useMeterContext();
+
+	return (
+		<Polymorphic<MeterTrackRenderProps>
+			as="div"
+			{...context.dataset()}
+			{...(props as MeterTrackProps)}
+		/>
+	);
+}

--- a/packages/core/src/meter/meter-value-label.tsx
+++ b/packages/core/src/meter/meter-value-label.tsx
@@ -1,0 +1,43 @@
+import type { JSX, ValidComponent } from "solid-js";
+
+import {
+	type ElementOf,
+	Polymorphic,
+	type PolymorphicProps,
+} from "../polymorphic";
+import { type MeterDataSet, useMeterContext } from "./meter-context";
+
+export interface MeterValueLabelOptions {}
+
+export interface MeterValueLabelCommonProps<
+	T extends HTMLElement = HTMLElement,
+> {}
+
+export interface MeterValueLabelRenderProps
+	extends MeterValueLabelCommonProps,
+		MeterDataSet {
+	children: JSX.Element;
+}
+
+export type MeterValueLabelProps<
+	T extends ValidComponent | HTMLElement = HTMLElement,
+> = MeterValueLabelOptions & Partial<MeterValueLabelCommonProps<ElementOf<T>>>;
+
+/**
+ * The accessible label text representing the current value in a human-readable format.
+ */
+export function MeterValueLabel<T extends ValidComponent = "div">(
+	props: PolymorphicProps<T, MeterValueLabelProps<T>>,
+) {
+	const context = useMeterContext();
+
+	return (
+		<Polymorphic<MeterValueLabelRenderProps>
+			as="div"
+			{...context.dataset()}
+			{...(props as MeterValueLabelProps)}
+		>
+			{context.valueLabel()}
+		</Polymorphic>
+	);
+}

--- a/packages/core/src/meter/meter.test.tsx
+++ b/packages/core/src/meter/meter.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Portions of this file are based on code from react-spectrum.
+ * Apache License Version 2.0, Copyright 2020 Adobe.
+ *
+ * Credits to the React Spectrum team:
+ * https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/meter/src/useMeter.ts
+ * https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/meter/test/Meter.test.js 
+ 
+*/
+
+import { render } from "@solidjs/testing-library";
+
+import * as Meter from ".";
+
+describe("Meter", () => {
+	it("handles defaults", () => {
+		const { getByRole, getByTestId } = render(() => (
+			<Meter.Root>
+				<Meter.Label>Meter</Meter.Label>
+				<Meter.ValueLabel data-testid="value-label" />
+				<Meter.Track>
+					<Meter.Fill />
+				</Meter.Track>
+			</Meter.Root>
+		));
+
+		const meter = getByRole("meter");
+		expect(meter).toHaveAttribute("aria-valuemin", "0");
+		expect(meter).toHaveAttribute("aria-valuemax", "100");
+		expect(meter).toHaveAttribute("aria-valuenow", "0");
+		expect(meter).toHaveAttribute("aria-valuetext", "0%");
+
+		const valueLabel = getByTestId("value-label");
+		expect(valueLabel).toHaveTextContent("0%");
+
+		const labelId = meter.getAttribute("aria-labelledby");
+		expect(labelId).toBeDefined();
+
+		const label = document.getElementById(labelId!);
+		expect(label).toHaveTextContent("Meter");
+	});
+
+	it("supports custom value label", () => {
+		const { getByRole, getByTestId } = render(() => (
+			<Meter.Root
+				value={3}
+				minValue={0}
+				maxValue={10}
+				getValueLabel={({ value, max }) => `${value} of ${max} completed`}
+			>
+				<Meter.Label>Meter</Meter.Label>
+				<Meter.ValueLabel data-testid="value-label" />
+				<Meter.Track>
+					<Meter.Fill />
+				</Meter.Track>
+			</Meter.Root>
+		));
+
+		const meter = getByRole("meter");
+		expect(meter).toHaveAttribute("aria-valuetext", "3 of 10 completed");
+
+		const valueLabel = getByTestId("value-label");
+		expect(valueLabel).toHaveTextContent("3 of 10 completed");
+	});
+
+	it("should update all fields by value", () => {
+		const { getByRole } = render(() => (
+			<Meter.Root value={30}>
+				<Meter.Label>Meter</Meter.Label>
+				<Meter.ValueLabel />
+				<Meter.Track>
+					<Meter.Fill />
+				</Meter.Track>
+			</Meter.Root>
+		));
+
+		const meter = getByRole("meter");
+
+		expect(meter).toHaveAttribute("aria-valuemin", "0");
+		expect(meter).toHaveAttribute("aria-valuemax", "100");
+		expect(meter).toHaveAttribute("aria-valuenow", "30");
+		expect(meter).toHaveAttribute("aria-valuetext", "30%");
+	});
+
+	it("should clamps values to 'minValue'", () => {
+		const { getByRole } = render(() => (
+			<Meter.Root value={-1} minValue={0}>
+				<Meter.Label>Meter</Meter.Label>
+				<Meter.ValueLabel />
+				<Meter.Track>
+					<Meter.Fill />
+				</Meter.Track>
+			</Meter.Root>
+		));
+
+		const meter = getByRole("meter");
+		expect(meter).toHaveAttribute("aria-valuenow", "0");
+		expect(meter).toHaveAttribute("aria-valuetext", "0%");
+	});
+
+	it("should clamps values to 'maxValue'", () => {
+		const { getByRole } = render(() => (
+			<Meter.Root value={200} maxValue={100}>
+				<Meter.Label>Meter</Meter.Label>
+				<Meter.ValueLabel />
+				<Meter.Track>
+					<Meter.Fill />
+				</Meter.Track>
+			</Meter.Root>
+		));
+
+		const meter = getByRole("meter");
+		expect(meter).toHaveAttribute("aria-valuenow", "100");
+		expect(meter).toHaveAttribute("aria-valuetext", "100%");
+	});
+
+	it("supports negative values", () => {
+		const { getByRole } = render(() => (
+			<Meter.Root value={0} minValue={-5} maxValue={5}>
+				<Meter.Label>Meter</Meter.Label>
+				<Meter.ValueLabel />
+				<Meter.Track>
+					<Meter.Fill />
+				</Meter.Track>
+			</Meter.Root>
+		));
+
+		const meter = getByRole("meter");
+		expect(meter).toHaveAttribute("aria-valuenow", "0");
+		expect(meter).toHaveAttribute("aria-valuetext", "50%");
+	});
+});

--- a/packages/core/src/progress/progress-context.tsx
+++ b/packages/core/src/progress/progress-context.tsx
@@ -1,19 +1,15 @@
 import { type Accessor, createContext, useContext } from "solid-js";
+import type { MeterContextValue, MeterDataSet } from "../meter/meter-context";
 
-export interface ProgressDataSet {
+export interface ProgressDataSet extends MeterDataSet {
 	"data-progress": "loading" | "complete" | undefined;
 	"data-indeterminate": string | undefined;
 }
 
-export interface ProgressContextValue {
+export interface ProgressContextValue
+	extends Omit<MeterContextValue, "dataset" | "meterFillWidth"> {
 	dataset: Accessor<ProgressDataSet>;
-	value: Accessor<number>;
-	valuePercent: Accessor<number>;
-	valueLabel: Accessor<string | undefined>;
 	progressFillWidth: Accessor<string | undefined>;
-	labelId: Accessor<string | undefined>;
-	generateId: (part: string) => string;
-	registerLabelId: (id: string) => () => void;
 }
 
 export const ProgressContext = createContext<ProgressContextValue>();

--- a/packages/core/src/progress/progress-fill.tsx
+++ b/packages/core/src/progress/progress-fill.tsx
@@ -1,6 +1,11 @@
 import { type JSX, type ValidComponent, splitProps } from "solid-js";
 
 import { combineStyle } from "@solid-primitives/props";
+import type {
+	MeterFillCommonProps,
+	MeterFillOptions,
+	MeterFillRenderProps,
+} from "../meter";
 import {
 	type ElementOf,
 	Polymorphic,
@@ -8,15 +13,15 @@ import {
 } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
 
-export interface ProgressFillOptions {}
+export interface ProgressFillOptions extends MeterFillOptions {}
 
-export interface ProgressFillCommonProps<T extends HTMLElement = HTMLElement> {
-	style?: JSX.CSSProperties | string;
-}
+export interface ProgressFillCommonProps<T extends HTMLElement = HTMLElement>
+	extends MeterFillCommonProps {}
 
 export interface ProgressFillRenderProps
 	extends ProgressFillCommonProps,
-		ProgressDataSet {}
+		ProgressDataSet,
+		MeterFillRenderProps {}
 
 export type ProgressFillProps<
 	T extends ValidComponent | HTMLElement = HTMLElement,

--- a/packages/core/src/progress/progress-fill.tsx
+++ b/packages/core/src/progress/progress-fill.tsx
@@ -1,14 +1,18 @@
-import { type JSX, type ValidComponent, splitProps } from "solid-js";
+import {
+	type Component,
+	type ValidComponent,
+	splitProps,
+} from "solid-js";
 
 import { combineStyle } from "@solid-primitives/props";
-import type {
-	MeterFillCommonProps,
-	MeterFillOptions,
-	MeterFillRenderProps,
+import {
+	Meter,
+	type MeterFillCommonProps,
+	type MeterFillOptions,
+	type MeterFillRenderProps,
 } from "../meter";
 import {
 	type ElementOf,
-	Polymorphic,
 	type PolymorphicProps,
 } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
@@ -39,8 +43,9 @@ export function ProgressFill<T extends ValidComponent = "div">(
 	const [local, others] = splitProps(props as ProgressFillProps, ["style"]);
 
 	return (
-		<Polymorphic<ProgressFillRenderProps>
-			as="div"
+		<Meter.Fill<
+			Component<Omit<ProgressFillRenderProps, keyof MeterFillRenderProps>>
+		>
 			style={combineStyle(
 				{
 					"--kb-progress-fill-width": context.progressFillWidth(),

--- a/packages/core/src/progress/progress-fill.tsx
+++ b/packages/core/src/progress/progress-fill.tsx
@@ -1,8 +1,4 @@
-import {
-	type Component,
-	type ValidComponent,
-	splitProps,
-} from "solid-js";
+import { type Component, type ValidComponent, splitProps } from "solid-js";
 
 import { combineStyle } from "@solid-primitives/props";
 import {
@@ -11,10 +7,7 @@ import {
 	type MeterFillOptions,
 	type MeterFillRenderProps,
 } from "../meter";
-import {
-	type ElementOf,
-	type PolymorphicProps,
-} from "../polymorphic";
+import type { ElementOf, PolymorphicProps } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
 
 export interface ProgressFillOptions extends MeterFillOptions {}

--- a/packages/core/src/progress/progress-label.tsx
+++ b/packages/core/src/progress/progress-label.tsx
@@ -13,10 +13,7 @@ import {
 	type MeterLabelOptions,
 	type MeterLabelRenderProps,
 } from "../meter";
-import {
-	type ElementOf,
-	type PolymorphicProps,
-} from "../polymorphic";
+import type { ElementOf, PolymorphicProps } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
 
 export interface ProgressLabelOptions extends MeterLabelOptions {}

--- a/packages/core/src/progress/progress-label.tsx
+++ b/packages/core/src/progress/progress-label.tsx
@@ -1,19 +1,20 @@
 import { mergeDefaultProps } from "@kobalte/utils";
 import {
+	type Component,
 	type ValidComponent,
 	createEffect,
 	onCleanup,
 	splitProps,
 } from "solid-js";
 
-import type {
-	MeterLabelCommonProps,
-	MeterLabelOptions,
-	MeterLabelRenderProps,
+import {
+	Meter,
+	type MeterLabelCommonProps,
+	type MeterLabelOptions,
+	type MeterLabelRenderProps,
 } from "../meter";
 import {
 	type ElementOf,
-	Polymorphic,
 	type PolymorphicProps,
 } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
@@ -46,14 +47,14 @@ export function ProgressLabel<T extends ValidComponent = "span">(
 		},
 		props as ProgressLabelProps,
 	);
-
 	const [local, others] = splitProps(mergedProps, ["id"]);
 
 	createEffect(() => onCleanup(context.registerLabelId(local.id)));
 
 	return (
-		<Polymorphic<ProgressLabelRenderProps>
-			as="span"
+		<Meter.Label<
+			Component<Omit<ProgressLabelRenderProps, keyof MeterLabelRenderProps>>
+		>
 			id={local.id}
 			{...context.dataset()}
 			{...others}

--- a/packages/core/src/progress/progress-label.tsx
+++ b/packages/core/src/progress/progress-label.tsx
@@ -6,6 +6,11 @@ import {
 	splitProps,
 } from "solid-js";
 
+import type {
+	MeterLabelCommonProps,
+	MeterLabelOptions,
+	MeterLabelRenderProps,
+} from "../meter";
 import {
 	type ElementOf,
 	Polymorphic,
@@ -13,14 +18,14 @@ import {
 } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
 
-export interface ProgressLabelOptions {}
+export interface ProgressLabelOptions extends MeterLabelOptions {}
 
-export interface ProgressLabelCommonProps<T extends HTMLElement = HTMLElement> {
-	id: string;
-}
+export interface ProgressLabelCommonProps<T extends HTMLElement = HTMLElement>
+	extends MeterLabelCommonProps {}
 
 export interface ProgressLabelRenderProps
-	extends ProgressLabelCommonProps,
+	extends MeterLabelRenderProps,
+		ProgressLabelCommonProps,
 		ProgressDataSet {}
 
 export type ProgressLabelProps<

--- a/packages/core/src/progress/progress-root.tsx
+++ b/packages/core/src/progress/progress-root.tsx
@@ -24,10 +24,7 @@ import {
 	type MeterRootOptions,
 	type MeterRootRenderProps,
 } from "../meter";
-import {
-	type ElementOf,
-	type PolymorphicProps,
-} from "../polymorphic";
+import type { ElementOf, PolymorphicProps } from "../polymorphic";
 import { createRegisterId } from "../primitives";
 import {
 	ProgressContext,

--- a/packages/core/src/progress/progress-root.tsx
+++ b/packages/core/src/progress/progress-root.tsx
@@ -17,6 +17,11 @@ import {
 } from "solid-js";
 
 import { createNumberFormatter } from "../i18n";
+import type {
+	MeterRootCommonProps,
+	MeterRootOptions,
+	MeterRootRenderProps,
+} from "../meter";
 import {
 	type ElementOf,
 	Polymorphic,
@@ -29,54 +34,19 @@ import {
 	type ProgressDataSet,
 } from "./progress-context";
 
-interface GetValueLabelParams {
-	value: number;
-	min: number;
-	max: number;
-}
-
-export interface ProgressRootOptions {
-	/**
-	 * The progress value.
-	 * @default 0
-	 */
-	value?: number;
-
-	/**
-	 * The minimum progress value.
-	 * @default 0
-	 */
-	minValue?: number;
-
-	/**
-	 * The maximum progress value.
-	 * @default 100
-	 */
-	maxValue?: number;
-
+export interface ProgressRootOptions extends MeterRootOptions {
 	/** Whether the progress is in an indeterminate state. */
 	indeterminate?: boolean;
-
-	/**
-	 * A function to get the accessible label text representing the current value in a human-readable format.
-	 * If not provided, the value label will be read as a percentage of the max value.
-	 */
-	getValueLabel?: (params: GetValueLabelParams) => string;
 }
 
-export interface ProgressRootCommonProps<T extends HTMLElement = HTMLElement> {
-	id: string;
-}
+export interface ProgressRootCommonProps<T extends HTMLElement = HTMLElement>
+	extends MeterRootCommonProps {}
 
 export interface ProgressRootRenderProps
 	extends ProgressRootCommonProps,
-		ProgressDataSet {
+		ProgressDataSet,
+		Omit<MeterRootRenderProps, "role"> {
 	role: "progressbar";
-	"aria-valuenow": number | undefined;
-	"aria-valuemin": number;
-	"aria-valuemax": number;
-	"aria-valuetext": string | undefined;
-	"aria-labelledby": string | undefined;
 }
 
 export type ProgressRootProps<

--- a/packages/core/src/progress/progress-root.tsx
+++ b/packages/core/src/progress/progress-root.tsx
@@ -9,6 +9,7 @@
 import { clamp, createGenerateId, mergeDefaultProps } from "@kobalte/utils";
 import {
 	type Accessor,
+	type Component,
 	type ValidComponent,
 	createMemo,
 	createSignal,
@@ -17,14 +18,14 @@ import {
 } from "solid-js";
 
 import { createNumberFormatter } from "../i18n";
-import type {
-	MeterRootCommonProps,
-	MeterRootOptions,
-	MeterRootRenderProps,
+import {
+	Meter,
+	type MeterRootCommonProps,
+	type MeterRootOptions,
+	type MeterRootRenderProps,
 } from "../meter";
 import {
 	type ElementOf,
-	Polymorphic,
 	type PolymorphicProps,
 } from "../polymorphic";
 import { createRegisterId } from "../primitives";
@@ -34,7 +35,8 @@ import {
 	type ProgressDataSet,
 } from "./progress-context";
 
-export interface ProgressRootOptions extends MeterRootOptions {
+export interface ProgressRootOptions
+	extends Omit<MeterRootOptions, "indeterminate"> {
 	/** Whether the progress is in an indeterminate state. */
 	indeterminate?: boolean;
 }
@@ -43,12 +45,11 @@ export interface ProgressRootCommonProps<T extends HTMLElement = HTMLElement>
 	extends MeterRootCommonProps {}
 
 export interface ProgressRootRenderProps
-	extends ProgressRootCommonProps,
-		ProgressDataSet,
-		Omit<MeterRootRenderProps, "role"> {
+	extends Omit<MeterRootRenderProps, "role">,
+		ProgressRootCommonProps,
+		ProgressDataSet {
 	role: "progressbar";
 }
-
 export type ProgressRootProps<
 	T extends ValidComponent | HTMLElement = HTMLElement,
 > = ProgressRootOptions & Partial<ProgressRootCommonProps<ElementOf<T>>>;
@@ -139,16 +140,13 @@ export function ProgressRoot<T extends ValidComponent = "div">(
 
 	return (
 		<ProgressContext.Provider value={context}>
-			<Polymorphic<ProgressRootRenderProps>
-				as="div"
+			<Meter<
+				Component<Omit<ProgressRootRenderProps, keyof MeterRootRenderProps>>
+			>
 				role="progressbar"
-				aria-valuenow={local.indeterminate ? undefined : value()}
-				aria-valuemin={local.minValue}
-				aria-valuemax={local.maxValue}
-				aria-valuetext={valueLabel()}
-				aria-labelledby={labelId()}
+				indeterminate={local.indeterminate || false}
 				{...dataset()}
-				{...others}
+				{...mergedProps}
 			/>
 		</ProgressContext.Provider>
 	);

--- a/packages/core/src/progress/progress-track.tsx
+++ b/packages/core/src/progress/progress-track.tsx
@@ -5,10 +5,7 @@ import {
 	type MeterTrackOptions,
 	type MeterTrackRenderProps,
 } from "../meter";
-import {
-	type ElementOf,
-	type PolymorphicProps,
-} from "../polymorphic";
+import type { ElementOf, PolymorphicProps } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
 
 export interface ProgressTrackOptions extends MeterTrackOptions {}

--- a/packages/core/src/progress/progress-track.tsx
+++ b/packages/core/src/progress/progress-track.tsx
@@ -1,4 +1,9 @@
 import type { ValidComponent } from "solid-js";
+import type {
+	MeterTrackCommonProps,
+	MeterTrackOptions,
+	MeterTrackRenderProps,
+} from "../meter";
 import {
 	type ElementOf,
 	Polymorphic,
@@ -6,14 +11,14 @@ import {
 } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
 
-export interface ProgressTrackOptions {}
+export interface ProgressTrackOptions extends MeterTrackOptions {}
 
-export interface ProgressTrackCommonProps<
-	T extends HTMLElement = HTMLElement,
-> {}
+export interface ProgressTrackCommonProps<T extends HTMLElement = HTMLElement>
+	extends MeterTrackCommonProps {}
 
 export interface ProgressTrackRenderProps
-	extends ProgressTrackCommonProps,
+	extends MeterTrackRenderProps,
+		ProgressTrackCommonProps,
 		ProgressDataSet {}
 
 export type ProgressTrackProps<

--- a/packages/core/src/progress/progress-track.tsx
+++ b/packages/core/src/progress/progress-track.tsx
@@ -1,12 +1,12 @@
-import type { ValidComponent } from "solid-js";
-import type {
-	MeterTrackCommonProps,
-	MeterTrackOptions,
-	MeterTrackRenderProps,
+import type { Component, ValidComponent } from "solid-js";
+import {
+	Meter,
+	type MeterTrackCommonProps,
+	type MeterTrackOptions,
+	type MeterTrackRenderProps,
 } from "../meter";
 import {
 	type ElementOf,
-	Polymorphic,
 	type PolymorphicProps,
 } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
@@ -35,8 +35,9 @@ export function ProgressTrack<T extends ValidComponent = "div">(
 	const context = useProgressContext();
 
 	return (
-		<Polymorphic<ProgressTrackRenderProps>
-			as="div"
+		<Meter.Track<
+			Component<Omit<ProgressTrackRenderProps, keyof MeterTrackRenderProps>>
+		>
 			{...context.dataset()}
 			{...(props as ProgressTrackProps)}
 		/>

--- a/packages/core/src/progress/progress-value-label.tsx
+++ b/packages/core/src/progress/progress-value-label.tsx
@@ -1,13 +1,13 @@
-import type { JSX, ValidComponent } from "solid-js";
+import type { Component, ValidComponent } from "solid-js";
 
-import type {
-	MeterValueLabelCommonProps,
-	MeterValueLabelOptions,
-	MeterValueLabelRenderProps,
+import {
+	Meter,
+	type MeterValueLabelCommonProps,
+	type MeterValueLabelOptions,
+	type MeterValueLabelRenderProps,
 } from "../meter";
 import {
 	type ElementOf,
-	Polymorphic,
 	type PolymorphicProps,
 } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
@@ -37,12 +37,13 @@ export function ProgressValueLabel<T extends ValidComponent = "div">(
 	const context = useProgressContext();
 
 	return (
-		<Polymorphic<ProgressValueLabelRenderProps>
-			as="div"
+		<Meter.ValueLabel<
+			Component<
+				Omit<ProgressValueLabelRenderProps, keyof MeterValueLabelRenderProps>
+			>
+		>
 			{...context.dataset()}
 			{...(props as ProgressValueLabelProps)}
-		>
-			{context.valueLabel()}
-		</Polymorphic>
+		/>
 	);
 }

--- a/packages/core/src/progress/progress-value-label.tsx
+++ b/packages/core/src/progress/progress-value-label.tsx
@@ -6,10 +6,7 @@ import {
 	type MeterValueLabelOptions,
 	type MeterValueLabelRenderProps,
 } from "../meter";
-import {
-	type ElementOf,
-	type PolymorphicProps,
-} from "../polymorphic";
+import type { ElementOf, PolymorphicProps } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
 
 export interface ProgressValueLabelOptions extends MeterValueLabelOptions {}

--- a/packages/core/src/progress/progress-value-label.tsx
+++ b/packages/core/src/progress/progress-value-label.tsx
@@ -1,5 +1,10 @@
 import type { JSX, ValidComponent } from "solid-js";
 
+import type {
+	MeterValueLabelCommonProps,
+	MeterValueLabelOptions,
+	MeterValueLabelRenderProps,
+} from "../meter";
 import {
 	type ElementOf,
 	Polymorphic,
@@ -7,17 +12,16 @@ import {
 } from "../polymorphic";
 import { type ProgressDataSet, useProgressContext } from "./progress-context";
 
-export interface ProgressValueLabelOptions {}
+export interface ProgressValueLabelOptions extends MeterValueLabelOptions {}
 
 export interface ProgressValueLabelCommonProps<
 	T extends HTMLElement = HTMLElement,
-> {}
+> extends MeterValueLabelCommonProps {}
 
 export interface ProgressValueLabelRenderProps
-	extends ProgressValueLabelCommonProps,
-		ProgressDataSet {
-	children: JSX.Element;
-}
+	extends MeterValueLabelRenderProps,
+		ProgressValueLabelCommonProps,
+		ProgressDataSet {}
 
 export type ProgressValueLabelProps<
 	T extends ValidComponent | HTMLElement = HTMLElement,


### PR DESCRIPTION
closes #316 

- [x] To create Meter component
- [x] To add examples for Meter
- [x] To add docs for Meter
- [x] Tests for Meter
- [x] To extend Meter in Progress bar component

### Description
- The Meter component is built on the same foundation as the Progress, sharing much of the same structure and logic.
- Key differences between the Meter and Progress bar components:
  - The Meter component will always display a determinate value.
  - Unlike the Progress, the Meter does not have loading or complete states, as it only reflects a specific, static value. 