### PR TITLE
fix(select): fix prop not working properly on hidden select input

### DIFF
--- a/packages/core/src/select/hidden-select-base.tsx
+++ b/packages/core/src/select/hidden-select-base.tsx
@@ -120,6 +120,7 @@ export function HiddenSelectBase(props: HiddenSelectBaseProps) {
 				disabled={formControlContext.isDisabled()}
 				readOnly={formControlContext.isReadOnly()}
 				onFocus={() => local.focusTrigger()}
+				value={local.selectionManager.firstSelectedKey() ?? ""}
 			/>
 			<select
 				ref={mergeRefs((el) => (ref = el), local.ref)}


### PR DESCRIPTION
Hello!

I've noticed that `<Select />` components don't honor the `required` attribute properly, so this PR assigns a `value` attribute (same one assigned to the `select` element) to the `input` inside of `<HiddenSelect />`.

I wanted to add a test for this issue but I ran into the `pointer-events` issue that makes you skip all the current `Select` tests.