### PR TITLE
feat(dropdown-menu): Generic Radio Group Values

### DIFF
--- a/packages/core/src/menu/menu-radio-group-context.tsx
+++ b/packages/core/src/menu/menu-radio-group-context.tsx
@@ -1,15 +1,15 @@
 import { type Accessor, createContext, useContext } from "solid-js";
 
-export interface MenuRadioGroupContextValue {
+export interface MenuRadioGroupContextValue<TValue = string> {
 	isDisabled: Accessor<boolean | undefined>;
-	isSelectedValue: (value: string) => boolean;
-	setSelectedValue: (value: string) => void;
+	isSelectedValue: (value: TValue) => boolean;
+	setSelectedValue: (value: TValue) => void;
 }
 
 export const MenuRadioGroupContext =
-	createContext<MenuRadioGroupContextValue>();
+	createContext<MenuRadioGroupContextValue<any>>();
 
-export function useMenuRadioGroupContext() {
+export function useMenuRadioGroupContext<TValue = string>() {
 	const context = useContext(MenuRadioGroupContext);
 
 	if (context === undefined) {
@@ -18,5 +18,5 @@ export function useMenuRadioGroupContext() {
 		);
 	}
 
-	return context;
+	return context as MenuRadioGroupContextValue<TValue>;
 }

--- a/packages/core/src/menu/menu-radio-group.tsx
+++ b/packages/core/src/menu/menu-radio-group.tsx
@@ -28,18 +28,18 @@ import {
 } from "./menu-radio-group-context";
 import { useMenuRootContext } from "./menu-root-context";
 
-export interface MenuRadioGroupOptions {
+export interface MenuRadioGroupOptions<TValue = string> {
 	/** The controlled value of the item radio to check. */
-	value?: string;
+	value?: TValue;
 
 	/**
 	 * The value of the item radio that should be checked when initially rendered.
 	 * Useful when you do not need to control the state of the menu radio group.
 	 */
-	defaultValue?: string;
+	defaultValue?: TValue;
 
 	/** Event handler called when the value changes. */
-	onChange?: (value: string) => void;
+	onChange?: (value: TValue) => void;
 
 	/** Whether the menu radio group is disabled. */
 	disabled?: boolean;
@@ -56,14 +56,17 @@ export interface MenuRadioGroupRenderProps
 
 export type MenuRadioGroupProps<
 	T extends ValidComponent | HTMLElement = HTMLElement,
-> = MenuRadioGroupOptions & Partial<MenuRadioGroupCommonProps<ElementOf<T>>>;
+	TValue = string,
+> = MenuRadioGroupOptions<TValue> &
+	Partial<MenuRadioGroupCommonProps<ElementOf<T>>>;
 
 /**
  * A container used to group multiple `Menu.RadioItem`s and manage the selection.
  */
-export function MenuRadioGroup<T extends ValidComponent = "div">(
-	props: PolymorphicProps<T, MenuRadioGroupProps<T>>,
-) {
+export function MenuRadioGroup<
+	T extends ValidComponent = "div",
+	TValue = string,
+>(props: PolymorphicProps<T, MenuRadioGroupProps<T, TValue>>) {
 	const rootContext = useMenuRootContext();
 
 	const defaultId = rootContext.generateId(`radiogroup-${createUniqueId()}`);
@@ -72,7 +75,7 @@ export function MenuRadioGroup<T extends ValidComponent = "div">(
 		{
 			id: defaultId,
 		},
-		props as MenuRadioGroupProps,
+		props as MenuRadioGroupProps<T, TValue>,
 	);
 
 	const [local, others] = splitProps(mergedProps, [
@@ -82,16 +85,17 @@ export function MenuRadioGroup<T extends ValidComponent = "div">(
 		"disabled",
 	]);
 
-	const [selected, setSelected] = createControllableSignal<string>({
+	const [selected, setSelected] = createControllableSignal<TValue>({
 		value: () => local.value,
 		defaultValue: () => local.defaultValue,
 		onChange: (value) => local.onChange?.(value),
 	});
 
-	const context: MenuRadioGroupContextValue = {
+	const context: MenuRadioGroupContextValue<TValue> = {
 		isDisabled: () => local.disabled,
-		isSelectedValue: (value: string) => value === selected(),
-		setSelectedValue: setSelected,
+		isSelectedValue: (value: TValue) => value === selected(),
+		setSelectedValue: (value: TValue) =>
+			setSelected(value as Exclude<TValue, Function>),
 	};
 
 	return (

--- a/packages/core/src/menu/menu-radio-item.tsx
+++ b/packages/core/src/menu/menu-radio-item.tsx
@@ -10,10 +10,10 @@ import {
 } from "./menu-item-base";
 import { useMenuRadioGroupContext } from "./menu-radio-group-context";
 
-export interface MenuRadioItemOptions
+export interface MenuRadioItemOptions<TValue = string>
 	extends Omit<MenuItemBaseOptions, "checked" | "indeterminate"> {
 	/** The value of the menu item radio. */
-	value: string;
+	value: TValue;
 }
 
 export interface MenuRadioItemCommonProps<T extends HTMLElement = HTMLElement>
@@ -27,19 +27,22 @@ export interface MenuRadioItemRenderProps
 
 export type MenuRadioItemProps<
 	T extends ValidComponent | HTMLElement = HTMLElement,
-> = MenuRadioItemOptions & Partial<MenuRadioItemCommonProps<ElementOf<T>>>;
+	TValue = string,
+> = MenuRadioItemOptions<TValue> &
+	Partial<MenuRadioItemCommonProps<ElementOf<T>>>;
 
 /**
  * An item that can be controlled and rendered like a radio.
  */
-export function MenuRadioItem<T extends ValidComponent = "div">(
-	props: PolymorphicProps<T, MenuRadioItemProps<T>>,
-) {
-	const context = useMenuRadioGroupContext();
+export function MenuRadioItem<
+	T extends ValidComponent = "div",
+	TValue = string,
+>(props: PolymorphicProps<T, MenuRadioItemProps<T, TValue>>) {
+	const context = useMenuRadioGroupContext<TValue>();
 
 	const mergedProps = mergeDefaultProps(
 		{ closeOnSelect: false },
-		props as MenuRadioItemProps,
+		props as MenuRadioItemProps<T, TValue>,
 	);
 
 	const [local, others] = splitProps(mergedProps, ["value", "onSelect"]);


### PR DESCRIPTION
Fixes #574

Adds a generic parameter `TValue` to `MenuRadioGroup` and `MenuRadioItem` which allows the use of other types (not just strings) as the value for the Radio Group and Radio Items in a Dropdown Menu