### PR TITLE
fix(colors): format color

### DIFF
--- a/packages/core/src/colors/utils.test.ts
+++ b/packages/core/src/colors/utils.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { parseColor } from './utils'
+import { ColorChannel } from './types';
+
+const hexValues = [
+	{ raw: '#000000', string: '#000000' },
+]
+const hexaValues = [
+	{ raw: '#00000080', string: '#00000080' },
+]
+const rgbValues = [
+	{ raw: 'rgb(50 100 200)', alfa: false, string: 'rgb(50 100 200)' },
+	{ raw: 'rgb(50 100 200 / 0.2)', alfa: true, string: 'rgb(50 100 200 / 0.2)' },
+	{ raw: 'rgb(50 100 200 / 20%)', alfa: true, string: 'rgb(50 100 200 / 0.2)' },
+	{ raw: 'rgba(50, 100, 200, 0.2)', alfa: true, string: 'rgb(50 100 200 / 0.2)' },
+	{ raw: 'rgb(50, 100, 200)', alfa: false, string: 'rgb(50 100 200)' },
+	{ raw: 'rgb(50,100,200)', alfa: false, string: 'rgb(50 100 200)' },
+]
+
+describe('parseColor', () => {
+	describe('RGBColor', () => {
+		it.each(rgbValues)('correct parse string %s to color', (item) => {
+			const result = parseColor(item.raw);
+			expect(result.getColorSpace()).toBe('rgb');
+			expect(result.getColorChannels()).toStrictEqual<[ColorChannel, ColorChannel, ColorChannel]>(['red', 'green', 'blue']);
+		})
+
+		it.each(rgbValues)('correct result toString', (item) => {
+			const result = parseColor(item.raw);
+			expect(result.toString()).toBe(item.string);
+		})
+
+		it('correct result toString from rgb to hex', () => {
+			const result = parseColor('rgb(0 0 0)');
+			expect(result.toString('hex')).toBe('#000000');
+		})
+
+		it('correct result toString from rgb to hexa', () => {
+			const result = parseColor('rgb(0 0 0 / 0.5)');
+			expect(result.toString('hexa')).toBe('#00000080');
+		})
+
+		it('correct result toString from rgb to hsl', () => {
+			const result = parseColor('rgb(50 100 200)');
+			expect(result.toFormat('hsl').toString('hsl')).toBe('hsl(220 60% 49.02%)');
+		})
+
+		it('correct result toString from rgb to hsla', () => {
+			const result = parseColor('rgb(50 100 200 / 0.5)');
+			expect(result.toFormat('hsla').toString('hsla')).toBe('hsla(220 60% 49.02% / 0.5)');
+		})
+
+		it.each(rgbValues)('correctly parses and converts %s to various formats', (item) => {
+			const result = parseColor(item.raw);
+
+			// Verify initial color space and channels
+			expect(result.getColorSpace()).toBe('rgb');
+			expect(result.getColorChannels()).toStrictEqual<[ColorChannel, ColorChannel, ColorChannel]>(['red', 'green', 'blue']);
+
+			// Verify string representation
+			expect(result.toString()).toBe(item.string);
+
+			// Verify conversion to hex
+			if (!item.alfa) {
+				expect(result.toString('hex')).toBe('#3264C8');
+			}
+
+			// Verify conversion to hexa
+			if (item.alfa) {
+				expect(result.toString('hexa')).toBe('#3264C880');
+			}
+
+			// Verify conversion to HSL
+			const hslResult = result.toFormat('hsl');
+			expect(hslResult.toString('hsl')).toBe('hsl(220 60% 49.02%)');
+
+			// Verify conversion to HSLA
+			if (item.alfa) {
+				const hslaResult = result.toFormat('hsla');
+				expect(hslaResult.toString('hsla')).toBe('hsla(220 60% 49.02% / 0.2)');
+			}
+
+			// Verify conversion to HSB
+			const hsbResult = result.toFormat('hsb');
+			expect(hsbResult.toString('hsb')).toBe('hsb(220 75% 78.43%)');
+
+			// Verify conversion to HSBA
+			if (item.alfa) {
+				const hsbaResult = result.toFormat('hsba');
+				expect(hsbaResult.toString('hsba')).toBe('hsba(220 75% 78.43% 0.2)');
+			}
+		});
+
+		it('throws an error for invalid color strings', () => {
+			const invalidColors = ['invalid', '#zzzzzz'];
+			invalidColors.forEach((color) => {
+				expect(() => parseColor(color)).toThrowError(`Invalid color value: ${color}`);
+			});
+		});
+
+		it('handles edge cases for alpha values', () => {
+			const result = parseColor('rgb(50 100 200 / 0)');
+			expect(result.toFormat('hsba').toString('hsba')).toBe('hsba(220 75% 78.43% 0)');
+		});
+	})
+});

--- a/packages/core/src/colors/utils.ts
+++ b/packages/core/src/colors/utils.ts
@@ -262,6 +262,7 @@ class RGBColor extends Color {
 		super();
 	}
 
+
 	static parse(value: string) {
 		let colors: Array<number | undefined> = [];
 		// matching #rgb, #rgba, #rrggbb, #rrggbbaa
@@ -280,7 +281,13 @@ class RGBColor extends Color {
 		// matching rgb(rrr, ggg, bbb), rgba(rrr, ggg, bbb, 0.a)
 		const match = value.match(/^rgba?\((.*)\)$/);
 		if (match?.[1]) {
-			colors = match[1].split(",").map((value) => Number(value.trim()));
+			colors = match[1]
+				.replace(/(\d+)%$/u, (_substring, numberValue) => (Number(numberValue) / 100).toString())
+				.replaceAll(/,|\//gu, ' ')
+				.replaceAll(/\s{2,}/gu,' ')
+				.split(" ").map((value) => {
+					return Number(value.trim())
+				});
 			colors = colors.map((num, i) => {
 				return clamp(num ?? 0, 0, i < 3 ? 255 : 1);
 			});
@@ -315,9 +322,9 @@ class RGBColor extends Color {
 						.toString(16)
 						.padStart(2, "0")
 				).toUpperCase()}`;
-			case "rgb":
-				return `rgb(${this.red}, ${this.green}, ${this.blue})`;
 			case "css":
+			case "rgb":
+				return `rgb(${this.red} ${this.green} ${this.blue}${this.alpha !==1 && this.alpha !== 100 ? ' / ' + this?.alpha  : ''})`;
 			case "rgba":
 				return `rgba(${this.red}, ${this.green}, ${this.blue}, ${this.alpha})`;
 			default:
@@ -521,9 +528,9 @@ class HSBColor extends Color {
 			case "hexa":
 				return this.toRGB().toString("hexa");
 			case "hsb":
-				return `hsb(${this.hue}, ${toFixedNumber(this.saturation, 2)}%, ${toFixedNumber(this.brightness, 2)}%)`;
+				return `hsb(${this.hue} ${toFixedNumber(this.saturation, 2)}% ${toFixedNumber(this.brightness, 2)}%)`;
 			case "hsba":
-				return `hsba(${this.hue}, ${toFixedNumber(this.saturation, 2)}%, ${toFixedNumber(this.brightness, 2)}%, ${this.alpha})`;
+				return `hsba(${this.hue} ${toFixedNumber(this.saturation, 2)}% ${toFixedNumber(this.brightness, 2)}% ${this.alpha})`;
 			default:
 				return this.toFormat(format).toString(format);
 		}
@@ -679,10 +686,10 @@ class HSLColor extends Color {
 			case "hexa":
 				return this.toRGB().toString("hexa");
 			case "hsl":
-				return `hsl(${this.hue}, ${toFixedNumber(this.saturation, 2)}%, ${toFixedNumber(this.lightness, 2)}%)`;
+				return `hsl(${this.hue} ${toFixedNumber(this.saturation, 2)}% ${toFixedNumber(this.lightness, 2)}%${this.alpha !==1 && this.alpha !== 100 ? ' / ' + this.alpha : ''})`;
 			case "css":
 			case "hsla":
-				return `hsla(${this.hue}, ${toFixedNumber(this.saturation, 2)}%, ${toFixedNumber(this.lightness, 2)}%, ${this.alpha})`;
+				return `hsla(${this.hue} ${toFixedNumber(this.saturation, 2)}% ${toFixedNumber(this.lightness, 2)}% / ${this.alpha})`;
 			default:
 				return this.toFormat(format).toString(format);
 		}


### PR DESCRIPTION
By default, commas are not needed in the color notation for **rgb**. You can also directly pass the alpha channel value in the notation. 
Also, in the future, it is worth considering the possibility of removing the **rgba** format
https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb
In fact this also applies to hsl https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl

