### PR TITLE
fix(color-channel-field): fix handling of alpha values

### DIFF
--- a/packages/core/src/color-channel-field/color-channel-field-root.tsx
+++ b/packages/core/src/color-channel-field/color-channel-field-root.tsx
@@ -1,4 +1,4 @@
-import { mergeDefaultProps } from "@kobalte/utils";
+import { mergeDefaultProps, clamp } from "@kobalte/utils";
 import {
 	type Component,
 	type ValidComponent,
@@ -48,7 +48,7 @@ export interface ColorChannelFieldRootCommonProps<
 
 export interface ColorChannelFieldRootRenderProps
 	extends ColorChannelFieldRootCommonProps,
-		NumberField.NumberFieldRootRenderProps {}
+	NumberField.NumberFieldRootRenderProps { }
 
 export type ColorChannelFieldRootProps<
 	T extends ValidComponent | HTMLElement = HTMLElement,
@@ -96,19 +96,18 @@ export function ColorChannelFieldRoot<T extends ValidComponent = "div">(
 	);
 
 	const onRawValueChange = (value: number) => {
-		setValue(
-			color()!.withChannelValue(
-				local.channel,
-				!Number.isNaN(value)
-					? Math.round(
-							Math.max(
-								Math.min(value * multiplier(), range().maxValue),
-								range().minValue,
-							),
-						)
-					: Number.NaN,
-			),
-		);
+		if (Number.isNaN(value)) {
+			setValue(color()!.withChannelValue(local.channel, Number.NaN));
+			return;
+		}
+
+		const clampedValue = clamp(value * multiplier(), range().minValue, range().maxValue);
+
+		const digits = formatOptions().maximumFractionDigits ?? 0;
+
+		const roundedValue = Math.round(clampedValue * (10 ** digits)) / (10 ** digits);
+
+		setValue(color()!.withChannelValue(local.channel, roundedValue));
 	};
 
 	return (

--- a/packages/core/src/colors/utils.ts
+++ b/packages/core/src/colors/utils.ts
@@ -454,7 +454,7 @@ class RGBColor extends Color {
 			case "blue":
 				return { style: "decimal" };
 			case "alpha":
-				return { style: "percent" };
+				return { style: "percent", maximumFractionDigits: 2 };
 			default:
 				throw new Error(`Unknown color channel: ${channel}`);
 		}
@@ -611,7 +611,7 @@ class HSBColor extends Color {
 			case "saturation":
 			case "brightness":
 			case "alpha":
-				return { style: "percent" };
+				return { style: "percent", maximumFractionDigits: 2 };
 			default:
 				throw new Error(`Unknown color channel: ${channel}`);
 		}
@@ -767,7 +767,7 @@ class HSLColor extends Color {
 			case "saturation":
 			case "lightness":
 			case "alpha":
-				return { style: "percent" };
+				return { style: "percent", maximumFractionDigits: 2 };
 			default:
 				throw new Error(`Unknown color channel: ${channel}`);
 		}


### PR DESCRIPTION
Fixes #589 

I refactored the `onRawValueChange` function for the `ColorChannelFieldRoot` component to be able to handle the values for the Alpha channel (Or any channel that would be in a range with fraction digits).

The first notable change I did was to de-inline the logic here that was quite difficult to read. I decomposed it by steps and applied early return pattern for the 'NaN edgecase'. But I know some people prefer conciseness, so please let me know if it would be preferred inlined it as it was.

I also used the `clamp` function from `@kobalte/utils` for the sake of DRY and clarity.

Now onto the main issue, I added the classic "multiply-round-divide" trick to be able to have values with fraction digits as is required for the alpha channel values. Instead of adding a special condition for alpha I decided to make use of the [Intl.NumberFormatOptions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits)'s `maximumFractionDigit` property to configure how many fraction digits should be handled. I used it as already exists in this type, but another solution would have been to include that value in the `ColorChannelRange` type.

It is my first time contributing here, please let me know about any concerns / ideas to improve this PR.