### PR TITLE
fix: Make toggle-group-item disabled state reactive

### DIFF
--- a/packages/core/src/toggle-group/toggle-group-item.tsx
+++ b/packages/core/src/toggle-group/toggle-group-item.tsx
@@ -99,7 +99,7 @@ export function ToggleGroupItem<T extends ValidComponent = "button">(
 		{
 			key: () => local.value,
 			selectionManager: selectionManager,
-			disabled: local.disabled || rootContext.isDisabled(),
+			disabled: isDisabled,
 		},
 		() => ref,
 	);


### PR DESCRIPTION
Fixes #594 by passing a function to the toggle-group-item `createSelectableItem` field.