### PR TITLE
fix: verify document.body exists before adding event listeners

### DIFF
--- a/packages/utils/src/run-after-transition.ts
+++ b/packages/utils/src/run-after-transition.ts
@@ -18,7 +18,7 @@ const transitionsByElement = new Map<EventTarget, Set<string>>();
 const transitionCallbacks = new Set<() => void>();
 
 function setupGlobalEvents() {
-	if (typeof window === "undefined") {
+	if (typeof window === "undefined" || document.body === null) {
 		return;
 	}
 


### PR DESCRIPTION
[Document.body](https://developer.mozilla.org/en-US/docs/Web/API/Document/body) may be null.
When it is, trying to call `addEventListener` on it throws an exception.