### PR TITLE
feat(tooltip): expose onCurrentPlacementChange

### DIFF
--- a/packages/core/src/tooltip/tooltip-root.tsx
+++ b/packages/core/src/tooltip/tooltip-root.tsx
@@ -54,7 +54,7 @@ let globalSkipDelayTimeout: number | undefined;
 export interface TooltipRootOptions
 	extends Omit<
 		PopperRootOptions,
-		"anchorRef" | "contentRef" | "onCurrentPlacementChange"
+		"anchorRef" | "contentRef"
 	> {
 	/** The controlled open state of the tooltip. */
 	open?: boolean;
@@ -137,6 +137,7 @@ export function TooltipRoot(props: TooltipRootProps) {
 		"skipDelayDuration",
 		"ignoreSafeArea",
 		"forceMount",
+		"onCurrentPlacementChange",
 	]);
 
 	let closeTimeoutId: number | undefined;
@@ -413,7 +414,10 @@ export function TooltipRoot(props: TooltipRootProps) {
 			<Popper
 				anchorRef={triggerRef}
 				contentRef={contentRef}
-				onCurrentPlacementChange={setCurrentPlacement}
+				onCurrentPlacementChange={(value) => {
+					setCurrentPlacement(value);
+					local.onCurrentPlacementChange?.(value);
+				}}
 				{...others}
 			/>
 		</TooltipContext.Provider>


### PR DESCRIPTION
currently Tooltip doesn't expose `onCurrentPlacementChange`, which is incredibly useful for correctly positioning the tooltip (especially, its tail)

additionally i think we should expose it as `data-side`, similar to [radix](https://www.radix-ui.com/primitives/docs/components/tooltip#content)

---

NB: i did not test my changes, since they are fairly trivial and i didn't feel like setting up the entire stack. would be nice if someone tested them 🙏