### PR TITLE
fix: use preventScroll when focusing hidden inputs

### DIFF
--- a/packages/core/src/checkbox/checkbox-control.tsx
+++ b/packages/core/src/checkbox/checkbox-control.tsx
@@ -53,7 +53,7 @@ export function CheckboxControl<T extends ValidComponent = "div">(
 		callHandler(e, local.onClick);
 
 		context.toggle();
-		context.inputRef()?.focus();
+		context.inputRef()?.focus({ preventScroll: true });
 	};
 
 	const onKeyDown: JSX.EventHandlerUnion<HTMLElement, KeyboardEvent> = (e) => {
@@ -61,7 +61,7 @@ export function CheckboxControl<T extends ValidComponent = "div">(
 
 		if (e.key === EventKey.Space) {
 			context.toggle();
-			context.inputRef()?.focus();
+			context.inputRef()?.focus({ preventScroll: true });
 		}
 	};
 

--- a/packages/core/src/combobox/combobox-hidden-select.tsx
+++ b/packages/core/src/combobox/combobox-hidden-select.tsx
@@ -23,7 +23,7 @@ export function ComboboxHiddenSelect(props: ComboboxHiddenSelectProps) {
 			isOpen={context.isOpen()}
 			isMultiple={context.isMultiple()}
 			isVirtualized={context.isVirtualized()}
-			focusTrigger={() => context.inputRef()?.focus()}
+			focusTrigger={() => context.inputRef()?.focus({ preventScroll: true })}
 			{...props}
 		/>
 	);

--- a/packages/core/src/combobox/combobox-trigger.tsx
+++ b/packages/core/src/combobox/combobox-trigger.tsx
@@ -105,7 +105,7 @@ export function ComboboxTrigger<T extends ValidComponent = "button">(
 			}
 
 			// Focus the input field in case it isn't focused yet.
-			context.inputRef()?.focus();
+			context.inputRef()?.focus({ preventScroll: true });
 		}
 	};
 

--- a/packages/core/src/number-field/number-field-vary-trigger.tsx
+++ b/packages/core/src/number-field/number-field-vary-trigger.tsx
@@ -68,7 +68,7 @@ export function NumberFieldVaryTrigger<T extends ValidComponent = "button">(
 					context.step() * (local.numberFieldVaryType === "increment" ? 1 : -1),
 				);
 
-				context.inputRef()?.focus();
+				context.inputRef()?.focus({ preventScroll: true });
 			}}
 			{...others}
 		/>

--- a/packages/core/src/radio-group/radio-group-item-control.tsx
+++ b/packages/core/src/radio-group/radio-group-item-control.tsx
@@ -51,7 +51,7 @@ export function RadioGroupItemControl<T extends ValidComponent = "div">(
 		callHandler(e, local.onClick);
 
 		context.select();
-		context.inputRef()?.focus();
+		context.inputRef()?.focus({ preventScroll: true });
 	};
 
 	const onKeyDown: JSX.EventHandlerUnion<any, KeyboardEvent> = (e) => {
@@ -59,7 +59,7 @@ export function RadioGroupItemControl<T extends ValidComponent = "div">(
 
 		if (e.key === EventKey.Space) {
 			context.select();
-			context.inputRef()?.focus();
+			context.inputRef()?.focus({ preventScroll: true });
 		}
 	};
 

--- a/packages/core/src/switch/switch-control.tsx
+++ b/packages/core/src/switch/switch-control.tsx
@@ -51,7 +51,7 @@ export function SwitchControl<T extends ValidComponent = "div">(
 		callHandler(e, local.onClick);
 
 		context.toggle();
-		context.inputRef()?.focus();
+		context.inputRef()?.focus({ preventScroll: true });
 	};
 
 	const onKeyDown: JSX.EventHandlerUnion<any, KeyboardEvent> = (e) => {
@@ -59,7 +59,7 @@ export function SwitchControl<T extends ValidComponent = "div">(
 
 		if (e.key === EventKey.Space) {
 			context.toggle();
-			context.inputRef()?.focus();
+			context.inputRef()?.focus({ preventScroll: true });
 		}
 	};
 


### PR DESCRIPTION
## Summary

When control elements (Checkbox, Switch, Radio, etc.) are clicked, they call `inputRef()?.focus()` to move focus to the visually-hidden input element. Because the input uses `position: absolute` with `clip: rect(0, 0, 0, 0)`, the browser's default focus-scroll behavior calculates a bogus scroll target, causing the scroll container to jump to an unexpected position.

This is especially noticeable when:
- The HTML/body elements are not the scroll container (a nested div is)
- The control is inside a scrollable panel or modal
- Multiple controls are stacked vertically

## Fix

Pass `{ preventScroll: true }` to all `focus()` calls on hidden input refs. This is a [standard DOM API](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#preventscroll) supported in all modern browsers that focuses the element without triggering scroll-into-view behavior.

## Affected components

- `Checkbox.Control`
- `Switch.Control`
- `RadioGroup.ItemControl`
- `NumberField.VaryTrigger`
- `Combobox.Trigger`
- `Combobox.HiddenSelect`

## Reproduction

See the [StackBlitz repro from #452](https://stackblitz.com/edit/solidjs-templates-ewgvx2?file=src%2FApp.tsx,src%2Findex.css) - clicking a checkbox in a scrollable container causes the page to jump.

Fixes #452