### PR TITLE
fix(dismissable-layer): guard isTopMostLayer against empty layers array

### DIFF
--- a/.changeset/guard-empty-layer-stack.md
+++ b/.changeset/guard-empty-layer-stack.md
@@ -1,0 +1,7 @@
+---
+'@kobalte/core': patch
+---
+
+fix(dismissable-layer): guard `isTopMostLayer` against an empty layer stack.
+
+When the dismissable-layer stack is empty (e.g. callbacks fired after the last layer has already been removed during teardown), `layers[layers.length - 1]` is `undefined` and reading `.node` on it throws `TypeError: Cannot read properties of undefined (reading 'node')`. Returning `false` early when there are no layers makes the predicate behave consistently with "no top-most layer is currently registered".

--- a/packages/core/src/dismissable-layer/layer-stack.tsx
+++ b/packages/core/src/dismissable-layer/layer-stack.tsx
@@ -36,7 +36,7 @@ function find(node: HTMLElement | undefined): LayerModel | undefined {
 }
 
 function isTopMostLayer(node: HTMLElement | null) {
-	return layers[layers.length - 1].node === node;
+	return layers.length > 0 && layers[layers.length - 1].node === node;
 }
 
 function getPointerBlockingLayers() {


### PR DESCRIPTION
## Problem

`isTopMostLayer` crashes with TypeError when layers array is empty.

### Root cause

`layers[layers.length - 1].node` throws when `layers` is empty, since `layers[-1]` is undefined. Can happen during teardown or before a layer is registered.

### Fix

Add a length guard:

```ts
function isTopMostLayer(node: HTMLElement | null) {
  return layers.length > 0 && layers[layers.length - 1].node === node;
}
```n
Returning `false` for an empty stack is correct — no layer is on top.

Fixes #649