### PR TITLE
fix(context-menu): always call user-provided onContextMenu on trigger

### DIFF
--- a/.changeset/context-menu-trigger-oncontextmenu.md
+++ b/.changeset/context-menu-trigger-oncontextmenu.md
@@ -1,0 +1,5 @@
+---
+"@kobalte/core": patch
+---
+
+fix(context-menu): always call the user-provided `onContextMenu` handler on `ContextMenu.Trigger`, not only when the trigger is disabled. The handler now runs in every case (giving consumers access to the event, e.g. pointer coordinates), and calling `event.preventDefault()` from it opts out of opening the menu.

--- a/packages/core/src/context-menu/context-menu-trigger.test.tsx
+++ b/packages/core/src/context-menu/context-menu-trigger.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render } from "@solidjs/testing-library";
+
+import * as ContextMenu from ".";
+
+// https://github.com/kobaltedev/kobalte/issues/646
+describe("ContextMenuTrigger onContextMenu", () => {
+	it("calls a provided onContextMenu handler when the trigger is not disabled", () => {
+		const onContextMenu = vi.fn();
+		const onOpenChange = vi.fn();
+
+		const { getByText } = render(() => (
+			<ContextMenu.Root onOpenChange={onOpenChange}>
+				<ContextMenu.Trigger onContextMenu={onContextMenu}>
+					Target
+				</ContextMenu.Trigger>
+			</ContextMenu.Root>
+		));
+
+		fireEvent.contextMenu(getByText("Target"));
+
+		expect(onContextMenu).toHaveBeenCalledTimes(1);
+		// The default behavior (opening the menu) is still preserved.
+		expect(onOpenChange).toHaveBeenCalledWith(true);
+	});
+
+	it("calls a provided onContextMenu handler when the trigger is disabled", () => {
+		const onContextMenu = vi.fn();
+
+		const { getByText } = render(() => (
+			<ContextMenu.Root>
+				<ContextMenu.Trigger disabled onContextMenu={onContextMenu}>
+					Target
+				</ContextMenu.Trigger>
+			</ContextMenu.Root>
+		));
+
+		fireEvent.contextMenu(getByText("Target"));
+
+		expect(onContextMenu).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not open the menu when the consumer calls preventDefault", () => {
+		const onOpenChange = vi.fn();
+
+		const { getByText } = render(() => (
+			<ContextMenu.Root onOpenChange={onOpenChange}>
+				<ContextMenu.Trigger onContextMenu={(e) => e.preventDefault()}>
+					Target
+				</ContextMenu.Trigger>
+			</ContextMenu.Root>
+		));
+
+		fireEvent.contextMenu(getByText("Target"));
+
+		expect(onOpenChange).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/context-menu/context-menu-trigger.tsx
+++ b/packages/core/src/context-menu/context-menu-trigger.tsx
@@ -87,9 +87,18 @@ export function ContextMenuTrigger<T extends ValidComponent = "div">(
 	});
 
 	const onContextMenu: JSX.EventHandlerUnion<HTMLElement, MouseEvent> = (e) => {
+		// Always call the user-provided handler so consumers can access the event
+		// (e.g. the pointer coordinates) and optionally opt out of the default
+		// behavior by calling `event.preventDefault()`.
+		callHandler(e, local.onContextMenu);
+
 		// If trigger is disabled, enable the native Context Menu.
 		if (local.disabled) {
-			callHandler(e, local.onContextMenu);
+			return;
+		}
+
+		// Allow consumers to prevent the menu from opening.
+		if (e.defaultPrevented) {
 			return;
 		}
 


### PR DESCRIPTION
## Problem

Closes #646.

`ContextMenu.Trigger` only forwarded a consumer-provided `onContextMenu` handler **when the trigger was `disabled`** ([context-menu-trigger.tsx#L90-L92](https://github.com/kobaltedev/kobalte/blob/main/packages/core/src/context-menu/context-menu-trigger.tsx#L90-L92)):

\\\	sx
const onContextMenu = (e) => {
  if (local.disabled) {
    callHandler(e, local.onContextMenu); // only here
    return;
  }
  // enabled path never calls the user handler...
};
\\\

In the normal (enabled) case the handler was silently dropped. This is:

- **Inconsistent with the trigger's own handlers** — `onPointerDown`/`onPointerMove`/`onPointerCancel`/`onPointerUp` all call `callHandler(e, local.onX)` first.
- **Inconsistent with the upstream Radix component** this file is based on, which composes the user handler and respects `defaultPrevented`.
- A real blocker for consumers who need the event (e.g. the pointer coordinates) while keeping the built-in long-press / positioning behavior.

## Fix

Call the user-provided `onContextMenu` in **all** cases, then honor `event.defaultPrevented` so consumers can opt out of opening the menu:

\\\	sx
callHandler(e, local.onContextMenu);
if (local.disabled) return;        // native context menu
if (e.defaultPrevented) return;    // consumer opted out
// ...open the menu (default behavior preserved)
\\\

The disabled behavior is unchanged. For enabled triggers the default behavior (opening the menu) is preserved unless the consumer calls `preventDefault()`.

## Tests

Added `packages/core/src/context-menu/context-menu-trigger.test.tsx` covering:

- handler is called when the trigger is **not** disabled (and the menu still opens),
- handler is called when the trigger **is** disabled (unchanged),
- the menu does **not** open when the consumer calls `preventDefault()`.

The first and third tests fail on `main` and pass with this change.

\\\
node vitest run src/context-menu/context-menu-trigger.test.tsx  ->  3 passed
node vitest run (full @kobalte/core suite)                       ->  491 passed | 112 skipped, 0 failed
biome check (changed files)                                     ->  no fixes needed
\\\

A changeset is included (`@kobalte/core` patch).

> Note: this PR intentionally does not add the anchor-rect getter to the context (also mentioned in #646); `preventDefault()` + the existing event already covers the "read the coordinates / opt out" use case with a minimal change.