### PR TITLE
chore: update createToggleState

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
 		"@internationalized/number": "^3.2.1",
 		"@kobalte/utils": "^0.9.2",
 		"@solid-primitives/a11y": "next",
-		"@solid-primitives/controlled-signal": "next",
+		"@solid-primitives/controlled-signal": "1.0.0-next.1",
 		"@solid-primitives/i18n": "next",
 		"@solid-primitives/focus": "next",
 		"@solid-primitives/form": "next",

--- a/packages/core/src/primitives/create-toggle-state/create-toggle-state.ts
+++ b/packages/core/src/primitives/create-toggle-state/create-toggle-state.ts
@@ -1,14 +1,8 @@
-/*
- * Portions of this file are based on code from react-spectrum.
- * Apache License Version 2.0, Copyright 2020 Adobe.
- *
- * Credits to the React Spectrum team:
- * https://github.com/adobe/react-spectrum/blob/a13802d8be6f83af1450e56f7a88527b10d9cadf/packages/@react-stately/toggle/src/useToggleState.ts
- */
-
 import { access, type MaybeAccessor } from "@kobalte/utils";
-import { createControllableBooleanSignal } from "@solid-primitives/controlled-signal";
-import type { Accessor } from "solid-js";
+import {
+	createToggleState as createControllableToggleState,
+	type ToggleState,
+} from "@solid-primitives/controlled-signal";
 
 export interface CreateToggleStateProps {
 	/** The controlled selected state. */
@@ -30,16 +24,7 @@ export interface CreateToggleStateProps {
 	onSelectedChange?: (isSelected: boolean) => void;
 }
 
-export interface ToggleState {
-	/** The selected state. */
-	isSelected: Accessor<boolean>;
-
-	/** Updates the selected state. */
-	setIsSelected: (isSelected: boolean) => void;
-
-	/** Toggle the selected state. */
-	toggle: () => void;
-}
+export type { ToggleState };
 
 /**
  * Provides state management for toggle components like checkboxes and switches.
@@ -47,27 +32,11 @@ export interface ToggleState {
 export function createToggleState(
 	props: CreateToggleStateProps = {},
 ): ToggleState {
-	const [isSelected, _setIsSelected] = createControllableBooleanSignal({
-		value: () => access(props.isSelected),
-		defaultValue: () => !!access(props.defaultIsSelected),
-		onChange: (value) => props.onSelectedChange?.(value),
+	return createControllableToggleState({
+		isSelected: () => access(props.isSelected),
+		defaultIsSelected: () => access(props.defaultIsSelected),
+		isDisabled: () => access(props.isDisabled),
+		isReadOnly: () => access(props.isReadOnly),
+		onSelectedChange: props.onSelectedChange,
 	});
-
-	const setIsSelected = (value: boolean) => {
-		if (!access(props.isReadOnly) && !access(props.isDisabled)) {
-			_setIsSelected(value);
-		}
-	};
-
-	const toggle = () => {
-		if (!access(props.isReadOnly) && !access(props.isDisabled)) {
-			_setIsSelected(!isSelected());
-		}
-	};
-
-	return {
-		isSelected,
-		setIsSelected,
-		toggle,
-	};
 }

--- a/packages/core/src/primitives/index.ts
+++ b/packages/core/src/primitives/index.ts
@@ -3,4 +3,8 @@ export * from "./create-collection";
 export * from "./create-disclosure-state";
 export * from "./create-register-id";
 export * from "./create-tag-name";
-export * from "./create-toggle-state";
+export {
+	createToggleState,
+	type CreateToggleStateProps,
+	type ToggleState,
+} from "./create-toggle-state";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@solidjs/testing-library': 1.0.0-beta.2
   '@solid-primitives/a11y': next
-  '@solid-primitives/controlled-signal': next
+  '@solid-primitives/controlled-signal': 1.0.0-next.1
   '@solid-primitives/event-listener': next
   '@solid-primitives/focus': next
   '@solid-primitives/form': next
@@ -265,8 +265,8 @@ importers:
         specifier: next
         version: 1.0.0-next.0(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)
       '@solid-primitives/controlled-signal':
-        specifier: next
-        version: 1.0.0-next.0(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)
+        specifier: 1.0.0-next.1
+        version: 1.0.0-next.1(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)
       '@solid-primitives/focus':
         specifier: next
         version: 1.0.0-next.0(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)
@@ -2914,8 +2914,8 @@ packages:
       '@solidjs/web': ^2.0.0-beta.15
       solid-js: ^2.0.0-beta.15
 
-  '@solid-primitives/controlled-signal@1.0.0-next.0':
-    resolution: {integrity: sha512-KLTFljQFM63WEMrzFFXSOO24nm+uSz2Mj79WYH8qdKSWRquuQPgVDJQnmVjaODJLHiZb2Z17s26oPKly0rVqGw==}
+  '@solid-primitives/controlled-signal@1.0.0-next.1':
+    resolution: {integrity: sha512-AE4HFWqOGr95FoabFgAFqyTjw8mBUXUISxxPCMbbU4id15mcyeIW/+cSzBq8b8n8so7V8SvvPnYn7TKyM9Eb5g==}
     peerDependencies:
       solid-js: ^2.0.0-beta.15
 
@@ -10166,7 +10166,7 @@ snapshots:
       '@solidjs/web': 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       solid-js: 2.0.0-beta.15
 
-  '@solid-primitives/controlled-signal@1.0.0-next.0(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)':
+  '@solid-primitives/controlled-signal@1.0.0-next.1(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)':
     dependencies:
       '@solid-primitives/utils': 7.0.0-next.0(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)
       solid-js: 2.0.0-beta.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
 overrides:
   "@solidjs/testing-library": "1.0.0-beta.2"
   "@solid-primitives/a11y": "next"
-  "@solid-primitives/controlled-signal": "next"
+  "@solid-primitives/controlled-signal": "1.0.0-next.1"
   "@solid-primitives/event-listener": "next"
   "@solid-primitives/focus": "next"
   "@solid-primitives/form": "next"
@@ -29,7 +29,7 @@ allowBuilds:
   esbuild: false
 minimumReleaseAgeExclude:
   - '@solid-primitives/a11y@1.0.0-next.0'
-  - '@solid-primitives/controlled-signal@1.0.0-next.0'
+  - '@solid-primitives/controlled-signal@1.0.0-next.1'
   - '@solid-primitives/event-listener@3.0.0-next.0'
   - '@solid-primitives/focus@1.0.0-next.0'
   - '@solid-primitives/form@1.0.0-next.0'


### PR DESCRIPTION
There was a request in Solid Primitives to add a toggle component. Decided to do so and also migrate createToggleState at the same time. This PR replaces the internally managed primitive with Solid Primitives 2.0 version.