### PR TITLE
add: Chip component

### DIFF
--- a/apps/docs/src/examples/chip.module.css
+++ b/apps/docs/src/examples/chip.module.css
@@ -1,4 +1,5 @@
 .chip {
+	position: relative;
 	display: inline-flex;
 	align-items: center;
 	gap: 0.375rem;
@@ -27,13 +28,38 @@
 	cursor: not-allowed;
 }
 
-.chip--selected {
+/* Selectable chip — composes `Checkbox`, following the same pattern used by
+ * MUI Joy's Chip (https://v7.mui.com/joy-ui/react-chip/#with-a-checkbox):
+ * the chip itself stays a static container, and a real checkbox input
+ * (stretched to cover the whole chip) owns all interaction/ARIA semantics. */
+.chip:has([data-checked]) {
 	background-color: hsl(200 98% 39%);
 	color: white;
 }
 
-.chip--selected[data-clickable]:hover {
-	background-color: hsl(201 96% 32%);
+/* The real interactive element (`.chip__checkbox-input`) is invisible, so the
+ * focus ring must be drawn on the chip itself when that input has keyboard focus. */
+.chip:has(.chip__checkbox-input:focus-visible) {
+	outline: 2px solid hsl(200 98% 39%);
+	outline-offset: 2px;
+}
+
+.chip__checkbox {
+	display: contents;
+}
+
+.chip__checkbox-input {
+	/* The size/position overrides that stretch this over the whole chip are
+	 * passed via the `style` prop instead of here — see the component code —
+	 * since that's merged after (and so wins over) Kobalte's default
+	 * visually-hidden input styles, which are also set inline. */
+	opacity: 0;
+	cursor: pointer;
+}
+
+.chip__checkbox-label {
+	/* Text sits visually on top of the input but must not intercept clicks itself. */
+	pointer-events: none;
 }
 
 .chip__delete-button {

--- a/apps/docs/src/examples/chip.module.css
+++ b/apps/docs/src/examples/chip.module.css
@@ -1,0 +1,59 @@
+.chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	border-radius: 9999px;
+	padding: 0.3em 0.4em 0.3em 0.8em;
+	background-color: hsl(240 5% 92%);
+	color: hsl(240 4% 16%);
+	font-size: 0.875rem;
+}
+
+.chip[data-clickable] {
+	cursor: pointer;
+}
+
+.chip[data-clickable]:hover {
+	background-color: hsl(240 5% 84%);
+}
+
+.chip[data-clickable]:focus-visible {
+	outline: 2px solid hsl(200 98% 39%);
+	outline-offset: 2px;
+}
+
+.chip[data-disabled] {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.chip--selected {
+	background-color: hsl(200 98% 39%);
+	color: white;
+}
+
+.chip--selected[data-clickable]:hover {
+	background-color: hsl(201 96% 32%);
+}
+
+.chip__delete-button {
+	appearance: none;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.25rem;
+	height: 1.25rem;
+	border: none;
+	border-radius: 9999px;
+	background-color: transparent;
+	color: inherit;
+	line-height: 0;
+}
+
+.chip__delete-button:hover:not(:disabled) {
+	background-color: hsl(240 5% 74%);
+}
+
+.chip__delete-button:disabled {
+	cursor: not-allowed;
+}

--- a/apps/docs/src/examples/chip.tsx
+++ b/apps/docs/src/examples/chip.tsx
@@ -1,3 +1,4 @@
+import { Checkbox } from "@kobalte/core/checkbox";
 import { Chip } from "@kobalte/core/chip";
 import { createSignal, For } from "solid-js";
 
@@ -19,6 +20,7 @@ export function BasicExample() {
 						<Chip.Delete
 							class={style["chip__delete-button"]}
 							onClick={() => removeTag(tag)}
+							aria-label={`Remove ${tag}`}
 						>
 							✕
 						</Chip.Delete>
@@ -30,29 +32,53 @@ export function BasicExample() {
 }
 
 export function ClickableExample() {
-	const [selected, setSelected] = createSignal<string[]>([]);
-	const options = ["React", "Solid", "Vue"];
+	return (
+		<div style={{ display: "flex", "flex-wrap": "wrap", gap: "0.5rem" }}>
+			<Chip class={style.chip} onClick={() => alert("Showing all React repos")}>
+				React
+			</Chip>
+			<Chip class={style.chip} onClick={() => alert("Showing all Solid repos")}>
+				Solid
+			</Chip>
+		</div>
+	);
+}
 
-	const toggle = (option: string) => {
-		setSelected((prev) =>
-			prev.includes(option)
-				? prev.filter((o) => o !== option)
-				: [...prev, option],
-		);
-	};
+/**
+ * Selectable (filter) chips, built the same way MUI Joy's `Chip` does it
+ * (https://v7.mui.com/joy-ui/react-chip/#with-a-checkbox): `Chip` stays a
+ * static container, and a real `Checkbox` — stretched to cover the whole
+ * chip — owns the interaction and ARIA semantics for the selected state.
+ */
+export function SelectableExample() {
+	const options = ["React", "Solid", "Vue"];
 
 	return (
 		<div style={{ display: "flex", "flex-wrap": "wrap", gap: "0.5rem" }}>
 			<For each={options}>
 				{(option) => (
-					<Chip
-						class={style.chip}
-						classList={{
-							[style["chip--selected"]]: selected().includes(option),
-						}}
-						onClick={() => toggle(option)}
-					>
-						{option}
+					<Chip class={style.chip}>
+						<Checkbox class={style.chip__checkbox}>
+							<Checkbox.Input
+								class={style["chip__checkbox-input"]}
+								style={{
+									position: "absolute",
+									inset: "0",
+									margin: "0",
+									width: "auto",
+									height: "auto",
+									padding: "0",
+									border: "0",
+									overflow: "visible",
+									clip: "auto",
+									"clip-path": "none",
+									"white-space": "normal",
+								}}
+							/>
+							<Checkbox.Label class={style["chip__checkbox-label"]}>
+								{option}
+							</Checkbox.Label>
+						</Checkbox>
 					</Chip>
 				)}
 			</For>

--- a/apps/docs/src/examples/chip.tsx
+++ b/apps/docs/src/examples/chip.tsx
@@ -1,0 +1,70 @@
+import { Chip } from "@kobalte/core/chip";
+import { createSignal, For } from "solid-js";
+
+import style from "./chip.module.css";
+
+export function BasicExample() {
+	const [tags, setTags] = createSignal(["Design", "Engineering", "Product"]);
+
+	const removeTag = (tag: string) => {
+		setTags((prev) => prev.filter((t) => t !== tag));
+	};
+
+	return (
+		<div style={{ display: "flex", "flex-wrap": "wrap", gap: "0.5rem" }}>
+			<For each={tags()}>
+				{(tag) => (
+					<Chip class={style.chip}>
+						{tag}
+						<Chip.Delete
+							class={style["chip__delete-button"]}
+							onClick={() => removeTag(tag)}
+						>
+							✕
+						</Chip.Delete>
+					</Chip>
+				)}
+			</For>
+		</div>
+	);
+}
+
+export function ClickableExample() {
+	const [selected, setSelected] = createSignal<string[]>([]);
+	const options = ["React", "Solid", "Vue"];
+
+	const toggle = (option: string) => {
+		setSelected((prev) =>
+			prev.includes(option)
+				? prev.filter((o) => o !== option)
+				: [...prev, option],
+		);
+	};
+
+	return (
+		<div style={{ display: "flex", "flex-wrap": "wrap", gap: "0.5rem" }}>
+			<For each={options}>
+				{(option) => (
+					<Chip
+						class={style.chip}
+						classList={{
+							[style["chip--selected"]]: selected().includes(option),
+						}}
+						onClick={() => toggle(option)}
+					>
+						{option}
+					</Chip>
+				)}
+			</For>
+		</div>
+	);
+}
+
+export function DisabledExample() {
+	return (
+		<Chip class={style.chip} disabled>
+			Archived
+			<Chip.Delete class={style["chip__delete-button"]}>✕</Chip.Delete>
+		</Chip>
+	);
+}

--- a/apps/docs/src/routes/docs/core.tsx
+++ b/apps/docs/src/routes/docs/core.tsx
@@ -69,6 +69,11 @@ const CORE_NAV_SECTIONS: NavSection[] = [
 				href: "/docs/core/components/checkbox",
 			},
 			{
+				title: "Chip",
+				href: "/docs/core/components/chip",
+				status: "new",
+			},
+			{
 				title: "Collapsible",
 				href: "/docs/core/components/collapsible",
 			},

--- a/apps/docs/src/routes/docs/core/components/chip.mdx
+++ b/apps/docs/src/routes/docs/core/components/chip.mdx
@@ -1,5 +1,5 @@
 import { Preview, Kbd, TabsSnippets } from "../../../../components";
-import { BasicExample, ClickableExample, DisabledExample } from "../../../../examples/chip";
+import { BasicExample, ClickableExample, SelectableExample, DisabledExample } from "../../../../examples/chip";
 
 # Chip
 
@@ -19,6 +19,7 @@ import { Root, Delete } from "@kobalte/core/chip";
 - Becomes keyboard-operable (`role="button"`, focusable, activatable with <Kbd>Space</Kbd> and <Kbd>Enter</Kbd>) as soon as an `onClick` handler is provided.
 - `Chip.Delete` stops its triggering event from propagating to `Chip`, so a chip can be clickable and deletable at the same time.
 - Localizable `aria-label` for `Chip.Delete` via the `translations` prop.
+- Selectable/filter chips are built by composing `Chip` with [Checkbox](/docs/core/components/checkbox) or a radio, the same way [MUI Joy's `Chip`](https://v7.mui.com/joy-ui/react-chip/#with-a-checkbox) does it — this gives selection real checkbox/radio ARIA semantics instead of a bespoke "pressed" state.
 
 ## Anatomy
 
@@ -63,7 +64,11 @@ The chip consists of:
           {(tag) => (
             <Chip class="chip">
               {tag}
-              <Chip.Delete class="chip__delete-button" onClick={() => removeTag(tag)}>
+              <Chip.Delete
+                class="chip__delete-button"
+                onClick={() => removeTag(tag)}
+                aria-label={`Remove ${tag}`}
+              >
                 ✕
               </Chip.Delete>
             </Chip>
@@ -123,6 +128,76 @@ Passing an `onClick` handler to `Chip` makes it keyboard-operable: it gets `role
 <Chip class="chip" onClick={() => console.log("clicked")}>
 	React
 </Chip>
+```
+
+### Selectable chip (filter chips)
+
+`Chip` intentionally has no built-in `selected`/`pressed` prop. For a selectable or filter chip, compose it with [Checkbox](/docs/core/components/checkbox) (multiple selection) or a radio (single selection) — this is the same approach [MUI Joy's `Chip`](https://v7.mui.com/joy-ui/react-chip/#with-a-checkbox) uses. `Chip` stays a static, non-interactive container; a real checkbox input — stretched to invisibly cover the whole chip — owns all interaction, keyboard support, and ARIA state (`aria-checked` via its native `checked` state, rather than a synthetic `aria-pressed`). The chip's own styling reacts to the nested checkbox's `data-checked` attribute using the CSS `:has()` selector, so no extra JavaScript wiring is needed.
+
+<Preview>
+	<SelectableExample />
+</Preview>
+
+```tsx
+import { Checkbox } from "@kobalte/core/checkbox";
+import { Chip } from "@kobalte/core/chip";
+
+<Chip class="chip">
+	<Checkbox class="chip__checkbox">
+		<Checkbox.Input
+			class="chip__checkbox-input"
+			style={{
+				position: "absolute",
+				inset: "0",
+				margin: "0",
+				width: "auto",
+				height: "auto",
+				padding: "0",
+				border: "0",
+				overflow: "visible",
+				clip: "auto",
+				"clip-path": "none",
+				"white-space": "normal",
+			}}
+		/>
+		<Checkbox.Label class="chip__checkbox-label">React</Checkbox.Label>
+	</Checkbox>
+</Chip>
+```
+
+```css
+.chip {
+	position: relative;
+	/* ...pill styles from the example above... */
+}
+
+/* Style the chip based on the nested checkbox's state. */
+.chip:has([data-checked]) {
+	background-color: hsl(200 98% 39%);
+	color: white;
+}
+
+/* The real interactive element is invisible, so draw focus on the chip itself. */
+.chip:has(.chip__checkbox-input:focus-visible) {
+	outline: 2px solid hsl(200 98% 39%);
+	outline-offset: 2px;
+}
+
+.chip__checkbox {
+	/* Removes the wrapper's own box so its children lay out as if they were
+	   direct children of `.chip`; the `style` prop above positions the input. */
+	display: contents;
+}
+
+.chip__checkbox-input {
+	opacity: 0;
+	cursor: pointer;
+}
+
+.chip__checkbox-label {
+	/* Must not intercept clicks itself — they should all reach the input underneath. */
+	pointer-events: none;
+}
 ```
 
 ### Disabled chip

--- a/apps/docs/src/routes/docs/core/components/chip.mdx
+++ b/apps/docs/src/routes/docs/core/components/chip.mdx
@@ -1,0 +1,178 @@
+import { Preview, Kbd, TabsSnippets } from "../../../../components";
+import { BasicExample, ClickableExample, DisabledExample } from "../../../../examples/chip";
+
+# Chip
+
+A compact element that represents an input, attribute, or action, such as a filter, a tag, or a contact.
+
+## Import
+
+```ts
+import { Chip } from "@kobalte/core/chip";
+// or
+import { Root, Delete } from "@kobalte/core/chip";
+```
+
+## Features
+
+- Renders as a static, non-interactive element by default.
+- Becomes keyboard-operable (`role="button"`, focusable, activatable with <Kbd>Space</Kbd> and <Kbd>Enter</Kbd>) as soon as an `onClick` handler is provided.
+- `Chip.Delete` stops its triggering event from propagating to `Chip`, so a chip can be clickable and deletable at the same time.
+- Localizable `aria-label` for `Chip.Delete` via the `translations` prop.
+
+## Anatomy
+
+The chip consists of:
+
+- **Chip:** The root container for the chip.
+- **Chip.Delete:** The button that removes the chip.
+
+```tsx
+<Chip>
+	<Chip.Delete />
+</Chip>
+```
+
+## Example
+
+<Preview>
+	<BasicExample />
+</Preview>
+
+<TabsSnippets>
+  <TabsSnippets.List>
+    <TabsSnippets.Trigger value="index.tsx">index.tsx</TabsSnippets.Trigger>
+    <TabsSnippets.Trigger value="style.css">style.css</TabsSnippets.Trigger>
+  </TabsSnippets.List>
+  {/* <!-- prettier-ignore-start -->*/}
+  <TabsSnippets.Content value="index.tsx">
+    ```tsx
+    import { Chip } from "@kobalte/core/chip";
+    import { createSignal, For } from "solid-js";
+    import "./style.css";
+
+    function App() {
+      const [tags, setTags] = createSignal(["Design", "Engineering", "Product"]);
+
+      const removeTag = (tag: string) => {
+        setTags((prev) => prev.filter((t) => t !== tag));
+      };
+
+      return (
+        <For each={tags()}>
+          {(tag) => (
+            <Chip class="chip">
+              {tag}
+              <Chip.Delete class="chip__delete-button" onClick={() => removeTag(tag)}>
+                ✕
+              </Chip.Delete>
+            </Chip>
+          )}
+        </For>
+      );
+    }
+    ```
+
+  </TabsSnippets.Content>
+  <TabsSnippets.Content value="style.css">
+    ```css
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 9999px;
+      padding: 0.3em 0.4em 0.3em 0.8em;
+      background-color: hsl(240 5% 92%);
+      color: hsl(240 4% 16%);
+      font-size: 14px;
+    }
+
+    .chip__delete-button {
+      appearance: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      border: none;
+      border-radius: 9999px;
+      background-color: transparent;
+      color: inherit;
+    }
+
+    .chip__delete-button:hover:not(:disabled) {
+      background-color: hsl(240 5% 74%);
+    }
+    ```
+
+  </TabsSnippets.Content>
+  {/* <!-- prettier-ignore-end -->*/}
+</TabsSnippets>
+
+## Usage
+
+### Clickable chip
+
+Passing an `onClick` handler to `Chip` makes it keyboard-operable: it gets `role="button"`, becomes focusable, and can be activated with <Kbd>Space</Kbd> or <Kbd>Enter</Kbd>, in addition to a `data-clickable` attribute for styling.
+
+<Preview>
+	<ClickableExample />
+</Preview>
+
+```tsx
+<Chip class="chip" onClick={() => console.log("clicked")}>
+	React
+</Chip>
+```
+
+### Disabled chip
+
+Setting `disabled` on `Chip` prevents its `onClick` from firing and removes it from the tab order. A nested `Chip.Delete` inherits the disabled state automatically.
+
+<Preview>
+	<DisabledExample />
+</Preview>
+
+```tsx
+<Chip class="chip" disabled>
+	Archived
+	<Chip.Delete class="chip__delete-button">✕</Chip.Delete>
+</Chip>
+```
+
+## API Reference
+
+### Chip
+
+`Chip` is equivalent to the `Root` import from `@kobalte/core/chip`.
+
+| Prop         | Description                                                                                       |
+| :----------- | :-------------------------------------------------------------------------------------------------- |
+| disabled     | `boolean` <br/> Whether the chip is disabled.                                                        |
+| onClick      | `JSX.EventHandlerUnion<T, MouseEvent>` <br/> Event handler called when the chip is clicked. Makes the chip keyboard-operable. |
+| translations | [`ChipIntlTranslations`](https://github.com/kobaltedev/kobalte/blob/main/packages/core/src/chip/chip.intl.ts) <br/> Localization strings. |
+
+| Data attribute | Description                                             |
+| :------------- | :------------------------------------------------------- |
+| data-disabled  | Present when the chip is disabled.                        |
+| data-clickable | Present when the chip has an `onClick` handler.           |
+
+### Chip.Delete
+
+`Chip.Delete` consists of [Button](/docs/core/components/button). It stops its triggering click/keyboard event from propagating to `Chip`, and inherits `Chip`'s `disabled` state unless overridden.
+
+## Rendered elements
+
+| Component      | Default rendered element |
+| :------------- | :------------------------ |
+| `Chip`         | `span`                     |
+| `Chip.Delete`  | `button`                   |
+
+## Accessibility
+
+### Keyboard Interactions
+
+| Key              | Description                                                    |
+| :--------------- | :--------------------------------------------------------------- |
+| <Kbd>Space</Kbd> | When focus is on a clickable chip (has `onClick`), activates it. |
+| <Kbd>Enter</Kbd> | When focus is on a clickable chip (has `onClick`), activates it. |

--- a/packages/core/src/chip/chip-context.tsx
+++ b/packages/core/src/chip/chip-context.tsx
@@ -1,0 +1,22 @@
+import { type Accessor, createContext, useContext } from "solid-js";
+
+import type { ChipIntlTranslations } from "./chip.intl";
+
+export interface ChipContextValue {
+	translations: Accessor<ChipIntlTranslations>;
+	disabled: Accessor<boolean>;
+}
+
+export const ChipContext = createContext<ChipContextValue>();
+
+export function useChipContext() {
+	const context = useContext(ChipContext);
+
+	if (context === undefined) {
+		throw new Error(
+			"[kobalte]: `useChipContext` must be used within a `Chip` component",
+		);
+	}
+
+	return context;
+}

--- a/packages/core/src/chip/chip-delete.tsx
+++ b/packages/core/src/chip/chip-delete.tsx
@@ -1,0 +1,52 @@
+import { callHandler } from "@kobalte/utils";
+import type { JSX, ValidComponent } from "@solidjs/web";
+import { type Component, omit } from "solid-js";
+
+import * as Button from "../button";
+import type { ElementOf, PolymorphicProps } from "../polymorphic";
+import { useChipContext } from "./chip-context";
+
+export interface ChipDeleteOptions extends Button.ButtonRootOptions {}
+
+export interface ChipDeleteCommonProps<T extends HTMLElement = HTMLElement>
+	extends Button.ButtonRootCommonProps<T> {
+	onClick: JSX.EventHandlerUnion<T, MouseEvent>;
+	"aria-label": string;
+}
+
+export interface ChipDeleteRenderProps
+	extends ChipDeleteCommonProps,
+		Button.ButtonRootRenderProps {}
+
+export type ChipDeleteProps<
+	T extends ValidComponent | HTMLElement = HTMLElement,
+> = ChipDeleteOptions & Partial<ChipDeleteCommonProps<ElementOf<T>>>;
+
+/**
+ * The button that removes the chip.
+ * Stops the triggering click/keyboard event from propagating to `Chip.Root`.
+ */
+export function ChipDelete<T extends ValidComponent = "button">(
+	props: PolymorphicProps<T, ChipDeleteProps<T>>,
+) {
+	const context = useChipContext();
+
+	const p = props as ChipDeleteProps;
+	const others = omit(p, "aria-label", "onClick", "disabled");
+
+	const onClick: JSX.EventHandlerUnion<HTMLElement, MouseEvent> = (e) => {
+		e.stopPropagation();
+		callHandler(e, p.onClick);
+	};
+
+	return (
+		<Button.Root<
+			Component<Omit<ChipDeleteRenderProps, keyof Button.ButtonRootRenderProps>>
+		>
+			aria-label={p["aria-label"] || context.translations().remove}
+			disabled={p.disabled ?? context.disabled()}
+			onClick={onClick}
+			{...others}
+		/>
+	);
+}

--- a/packages/core/src/chip/chip-root.tsx
+++ b/packages/core/src/chip/chip-root.tsx
@@ -1,0 +1,127 @@
+import { callHandler, mergeDefaultProps, mergeRefs } from "@kobalte/utils";
+import type { JSX, ValidComponent } from "@solidjs/web";
+import { createMemo, createSignal, omit } from "solid-js";
+
+import {
+	type ElementOf,
+	Polymorphic,
+	type PolymorphicProps,
+} from "../polymorphic";
+import { createTagName } from "../primitives";
+import { CHIP_INTL_TRANSLATIONS, type ChipIntlTranslations } from "./chip.intl";
+import { ChipContext, type ChipContextValue } from "./chip-context";
+
+export interface ChipRootOptions {
+	/** Whether the chip is disabled. */
+	disabled?: boolean;
+
+	/** The localized strings of the component. */
+	translations?: ChipIntlTranslations;
+}
+
+export interface ChipRootCommonProps<T extends HTMLElement = HTMLElement> {
+	ref: T | ((el: T) => void);
+	onClick?: JSX.EventHandlerUnion<T, MouseEvent>;
+	onKeyDown?: JSX.EventHandlerUnion<T, KeyboardEvent>;
+}
+
+export interface ChipRootRenderProps extends ChipRootCommonProps {
+	role: "button" | undefined;
+	tabindex: number | undefined;
+	"aria-disabled": "true" | undefined;
+	"data-disabled": string | undefined;
+	"data-clickable": string | undefined;
+}
+
+export type ChipRootProps<
+	T extends ValidComponent | HTMLElement = HTMLElement,
+> = ChipRootOptions & Partial<ChipRootCommonProps<ElementOf<T>>>;
+
+/**
+ * Chip is a compact element that represents an input, attribute, or action, such as a filter, a tag, or a contact.
+ * It becomes keyboard-operable as soon as an `onClick` handler is provided.
+ */
+export function ChipRoot<T extends ValidComponent = "span">(
+	props: PolymorphicProps<T, ChipRootProps<T>>,
+) {
+	const [ref, setRef] = createSignal<HTMLElement | undefined>(undefined, {
+		ownedWrite: true,
+	});
+
+	const mergedProps = mergeDefaultProps(
+		{ translations: CHIP_INTL_TRANSLATIONS },
+		props as ChipRootProps,
+	);
+
+	const others = omit(
+		mergedProps,
+		"ref",
+		"disabled",
+		"translations",
+		"onClick",
+		"onKeyDown",
+	);
+
+	const tagName = createTagName(ref, () => "span");
+
+	const isNativeInteractive = createMemo(() => {
+		const currentTagName = tagName();
+
+		if (currentTagName === "button") {
+			return true;
+		}
+
+		return currentTagName === "a" && ref()?.getAttribute("href") != null;
+	});
+
+	const isClickable = createMemo(() => mergedProps.onClick != null);
+
+	const disabled = () => mergedProps.disabled ?? false;
+
+	const onClick: JSX.EventHandlerUnion<HTMLElement, MouseEvent> = (e) => {
+		if (disabled()) {
+			e.preventDefault();
+			e.stopPropagation();
+			return;
+		}
+
+		callHandler(e, mergedProps.onClick);
+	};
+
+	const onKeyDown: JSX.EventHandlerUnion<HTMLElement, KeyboardEvent> = (e) => {
+		callHandler(e, mergedProps.onKeyDown);
+
+		if (disabled() || isNativeInteractive() || !isClickable()) {
+			return;
+		}
+
+		if (e.key === "Enter" || e.key === " ") {
+			e.preventDefault();
+			(e.currentTarget as HTMLElement).click();
+		}
+	};
+
+	const context: ChipContextValue = {
+		translations: () => mergedProps.translations!,
+		disabled,
+	};
+
+	return (
+		<ChipContext value={context}>
+			<Polymorphic<ChipRootRenderProps>
+				as="span"
+				ref={mergeRefs(setRef, mergedProps.ref)}
+				role={!isNativeInteractive() && isClickable() ? "button" : undefined}
+				tabindex={
+					!isNativeInteractive() && isClickable() && !disabled() ? 0 : undefined
+				}
+				aria-disabled={disabled() ? "true" : undefined}
+				data-disabled={disabled() ? "" : undefined}
+				data-clickable={isClickable() ? "" : undefined}
+				onClick={onClick}
+				onKeyDown={onKeyDown}
+				{...others}
+			/>
+		</ChipContext>
+	);
+}

--- a/packages/core/src/chip/chip-root.tsx
+++ b/packages/core/src/chip/chip-root.tsx
@@ -12,15 +12,14 @@ import { CHIP_INTL_TRANSLATIONS, type ChipIntlTranslations } from "./chip.intl";
 import { ChipContext, type ChipContextValue } from "./chip-context";
 
 export interface ChipRootOptions {
-	/** Whether the chip is disabled. */
-	disabled?: boolean;
-
 	/** The localized strings of the component. */
 	translations?: ChipIntlTranslations;
 }
 
 export interface ChipRootCommonProps<T extends HTMLElement = HTMLElement> {
 	ref: T | ((el: T) => void);
+	/** Whether the chip is disabled. */
+	disabled: boolean | undefined;
 	onClick?: JSX.EventHandlerUnion<T, MouseEvent>;
 	onKeyDown?: JSX.EventHandlerUnion<T, KeyboardEvent>;
 }
@@ -64,15 +63,15 @@ export function ChipRoot<T extends ValidComponent = "span">(
 
 	const tagName = createTagName(ref, () => "span");
 
-	const isNativeInteractive = createMemo(() => {
-		const currentTagName = tagName();
+	const isNativeButton = createMemo(() => tagName() === "button");
 
-		if (currentTagName === "button") {
-			return true;
-		}
+	const isNativeLink = createMemo(
+		() => tagName() === "a" && ref()?.getAttribute("href") != null,
+	);
 
-		return currentTagName === "a" && ref()?.getAttribute("href") != null;
-	});
+	const isNativeInteractive = createMemo(
+		() => isNativeButton() || isNativeLink(),
+	);
 
 	const isClickable = createMemo(() => mergedProps.onClick != null);
 
@@ -111,11 +110,12 @@ export function ChipRoot<T extends ValidComponent = "span">(
 			<Polymorphic<ChipRootRenderProps>
 				as="span"
 				ref={mergeRefs(setRef, mergedProps.ref)}
+				disabled={isNativeButton() ? disabled() : undefined}
 				role={!isNativeInteractive() && isClickable() ? "button" : undefined}
 				tabindex={
 					!isNativeInteractive() && isClickable() && !disabled() ? 0 : undefined
 				}
-				aria-disabled={disabled() ? "true" : undefined}
+				aria-disabled={!isNativeButton() && disabled() ? "true" : undefined}
 				data-disabled={disabled() ? "" : undefined}
 				data-clickable={isClickable() ? "" : undefined}
 				onClick={onClick}

--- a/packages/core/src/chip/chip.intl.ts
+++ b/packages/core/src/chip/chip.intl.ts
@@ -1,0 +1,6 @@
+export const CHIP_INTL_TRANSLATIONS = {
+	// `aria-label` of Chip.Delete.
+	remove: "Remove",
+};
+
+export type ChipIntlTranslations = typeof CHIP_INTL_TRANSLATIONS;

--- a/packages/core/src/chip/chip.test.tsx
+++ b/packages/core/src/chip/chip.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render } from "@solidjs/testing-library";
+import { vi } from "vitest";
+
+import * as Chip from ".";
+
+describe("Chip", () => {
+	it("renders as a static, non-interactive span by default", () => {
+		const { getByTestId } = render(() => (
+			<Chip.Root data-testid="chip">Default</Chip.Root>
+		));
+
+		const chip = getByTestId("chip");
+
+		expect(chip.tagName).toBe("SPAN");
+		expect(chip).not.toHaveAttribute("role");
+		expect(chip).not.toHaveAttribute("tabindex");
+		expect(chip).not.toHaveAttribute("data-clickable");
+	});
+
+	it("becomes keyboard-operable when 'onClick' is provided", () => {
+		const onClickSpy = vi.fn();
+
+		const { getByTestId } = render(() => (
+			<Chip.Root data-testid="chip" onClick={onClickSpy}>
+				Clickable
+			</Chip.Root>
+		));
+
+		const chip = getByTestId("chip");
+
+		expect(chip).toHaveAttribute("role", "button");
+		expect(chip).toHaveAttribute("tabindex", "0");
+		expect(chip).toHaveAttribute("data-clickable");
+
+		fireEvent.click(chip);
+		expect(onClickSpy).toHaveBeenCalledTimes(1);
+
+		fireEvent.keyDown(chip, { key: "Enter" });
+		expect(onClickSpy).toHaveBeenCalledTimes(2);
+
+		fireEvent.keyDown(chip, { key: " " });
+		expect(onClickSpy).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not add synthetic 'role=button' when rendered as a native button", () => {
+		const { getByTestId } = render(() => (
+			<Chip.Root data-testid="chip" as="button" onClick={() => {}}>
+				Clickable
+			</Chip.Root>
+		));
+
+		const chip = getByTestId("chip");
+
+		expect(chip).not.toHaveAttribute("role");
+		expect(chip).not.toHaveAttribute("tabindex");
+	});
+
+	it("does not fire 'onClick' and removes tabindex when disabled", () => {
+		const onClickSpy = vi.fn();
+
+		const { getByTestId } = render(() => (
+			<Chip.Root data-testid="chip" disabled onClick={onClickSpy}>
+				Clickable
+			</Chip.Root>
+		));
+
+		const chip = getByTestId("chip");
+
+		expect(chip).not.toHaveAttribute("tabindex");
+		expect(chip).toHaveAttribute("aria-disabled", "true");
+		expect(chip).toHaveAttribute("data-disabled");
+
+		fireEvent.click(chip);
+		expect(onClickSpy).not.toHaveBeenCalled();
+	});
+
+	describe("Chip.Delete", () => {
+		it("has a default 'aria-label' from translations", () => {
+			const { getByRole } = render(() => (
+				<Chip.Root>
+					Tag
+					<Chip.Delete />
+				</Chip.Root>
+			));
+
+			expect(getByRole("button")).toHaveAttribute("aria-label", "Remove");
+		});
+
+		it("supports a custom 'aria-label'", () => {
+			const { getByRole } = render(() => (
+				<Chip.Root>
+					Tag
+					<Chip.Delete aria-label="Remove tag" />
+				</Chip.Root>
+			));
+
+			expect(getByRole("button")).toHaveAttribute("aria-label", "Remove tag");
+		});
+
+		it("calls 'onClick' without triggering the chip's own 'onClick'", () => {
+			const onChipClickSpy = vi.fn();
+			const onDeleteClickSpy = vi.fn();
+
+			const { getByTestId } = render(() => (
+				<Chip.Root data-testid="chip" onClick={onChipClickSpy}>
+					Tag
+					<Chip.Delete data-testid="delete" onClick={onDeleteClickSpy} />
+				</Chip.Root>
+			));
+
+			fireEvent.click(getByTestId("delete"));
+
+			expect(onDeleteClickSpy).toHaveBeenCalledTimes(1);
+			expect(onChipClickSpy).not.toHaveBeenCalled();
+		});
+
+		it("is disabled when the parent 'Chip.Root' is disabled", () => {
+			const { getByRole } = render(() => (
+				<Chip.Root disabled>
+					Tag
+					<Chip.Delete />
+				</Chip.Root>
+			));
+
+			expect(getByRole("button")).toHaveAttribute("disabled");
+		});
+	});
+});

--- a/packages/core/src/chip/chip.test.tsx
+++ b/packages/core/src/chip/chip.test.tsx
@@ -74,6 +74,19 @@ describe("Chip", () => {
 		expect(onClickSpy).not.toHaveBeenCalled();
 	});
 
+	it("forwards the native 'disabled' attribute when rendered as a native button", () => {
+		const { getByTestId } = render(() => (
+			<Chip.Root data-testid="chip" as="button" disabled onClick={() => {}}>
+				Clickable
+			</Chip.Root>
+		));
+
+		const chip = getByTestId("chip");
+
+		expect(chip).toHaveAttribute("disabled");
+		expect(chip).not.toHaveAttribute("aria-disabled");
+	});
+
 	describe("Chip.Delete", () => {
 		it("has a default 'aria-label' from translations", () => {
 			const { getByRole } = render(() => (

--- a/packages/core/src/chip/index.tsx
+++ b/packages/core/src/chip/index.tsx
@@ -1,0 +1,35 @@
+import {
+	type ChipDeleteCommonProps,
+	type ChipDeleteOptions,
+	type ChipDeleteProps,
+	type ChipDeleteRenderProps,
+	ChipDelete as Delete,
+} from "./chip-delete";
+import {
+	type ChipRootCommonProps,
+	type ChipRootOptions,
+	type ChipRootProps,
+	type ChipRootRenderProps,
+	ChipRoot as Root,
+} from "./chip-root";
+
+export type {
+	ChipDeleteCommonProps,
+	ChipDeleteOptions,
+	ChipDeleteProps,
+	ChipDeleteRenderProps,
+	ChipRootCommonProps,
+	ChipRootOptions,
+	ChipRootProps,
+	ChipRootRenderProps,
+};
+export { Delete, Root };
+
+export const Chip = Object.assign(Root, {
+	Delete,
+});
+
+/**
+ * API will most probably change
+ */
+export { type ChipContextValue, useChipContext } from "./chip-context";

--- a/packages/core/src/chip/stories/chip.stories.tsx
+++ b/packages/core/src/chip/stories/chip.stories.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For } from "solid-js";
 import preview from "../../../../../.storybook/preview.js";
+import * as Checkbox from "../../checkbox";
 import { Delete, Root } from "../index";
 
 const meta = preview.meta({
@@ -33,28 +34,67 @@ export const Default = meta.story({
 	),
 });
 
-/** Passing `onClick` makes the chip keyboard-operable (`role="button"`, focusable, Enter/Space activate it). */
-function ClickableDemo() {
-	const [selected, setSelected] = createSignal<string[]>([]);
+/** Passing `onClick` makes the chip keyboard-operable (`role="button"`, focusable, Enter/Space activate it). Use this for one-off actions, not selection — see "Selectable" for that. */
+export const Clickable = meta.story({
+	name: "Clickable",
+	render: () => (
+		<div class="flex flex-wrap gap-2 font-sans">
+			<Root
+				class={`${baseClass} ${clickableClass}`}
+				onClick={() => alert("React repos")}
+			>
+				React
+			</Root>
+			<Root
+				class={`${baseClass} ${clickableClass}`}
+				onClick={() => alert("Solid repos")}
+			>
+				Solid
+			</Root>
+		</div>
+	),
+});
+
+/**
+ * `Chip` has no built-in `selected`/`pressed` prop. Selectable (filter) chips are built by
+ * composing `Chip` with `Checkbox` — the same approach MUI Joy's `Chip` uses
+ * (https://v7.mui.com/joy-ui/react-chip/#with-a-checkbox). A real checkbox input, stretched to
+ * invisibly cover the whole chip, owns interaction and ARIA state; the chip reacts to the nested
+ * checkbox's `data-checked` via the CSS `:has()` selector — no extra JS wiring needed.
+ */
+function SelectableDemo() {
 	const options = ["React", "Solid", "Vue", "Svelte"];
 
-	const toggle = (value: string) => {
-		setSelected((prev) =>
-			prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value],
-		);
-	};
+	const overlayStyle = {
+		position: "absolute",
+		inset: "0",
+		margin: "0",
+		width: "auto",
+		height: "auto",
+		padding: "0",
+		border: "0",
+		overflow: "visible",
+		clip: "auto",
+		"clip-path": "none",
+		"white-space": "normal",
+	} as const;
 
 	return (
 		<div class="flex flex-wrap gap-2 font-sans">
 			<For each={options}>
 				{(option) => (
 					<Root
-						class={`${baseClass} ${clickableClass} ${
-							selected().includes(option) ? "bg-blue-600 text-white" : ""
-						}`}
-						onClick={() => toggle(option)}
+						class={`${baseClass} relative has-[[data-checked]]:bg-blue-600 has-[[data-checked]]:text-white has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-500`}
 					>
-						{option}
+						<Checkbox.Root class="contents">
+							<Checkbox.Input
+								class="opacity-0 cursor-pointer"
+								style={overlayStyle}
+							/>
+							<Checkbox.Label class="pointer-events-none">
+								{option}
+							</Checkbox.Label>
+						</Checkbox.Root>
 					</Root>
 				)}
 			</For>
@@ -62,9 +102,9 @@ function ClickableDemo() {
 	);
 }
 
-export const Clickable = meta.story({
-	name: "Clickable",
-	render: () => <ClickableDemo />,
+export const Selectable = meta.story({
+	name: "Selectable",
+	render: () => <SelectableDemo />,
 });
 
 /** `Chip.Delete` stops its click from bubbling to `Chip.Root`, so removal and selection can coexist. */

--- a/packages/core/src/chip/stories/chip.stories.tsx
+++ b/packages/core/src/chip/stories/chip.stories.tsx
@@ -1,0 +1,134 @@
+import { createSignal, For } from "solid-js";
+import preview from "../../../../../.storybook/preview.js";
+import { Delete, Root } from "../index";
+
+const meta = preview.meta({
+	title: "Components/Chip",
+	tags: ["autodocs"],
+});
+
+export default meta;
+
+const baseClass =
+	"inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium bg-slate-100 text-slate-700";
+
+const clickableClass =
+	"data-[clickable]:cursor-pointer data-[clickable]:hover:bg-slate-200 data-[clickable]:focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500";
+
+const disabledClass =
+	"data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed";
+
+const deleteButtonClass =
+	"inline-flex items-center justify-center rounded-full size-4 hover:bg-slate-300 disabled:cursor-not-allowed disabled:hover:bg-transparent";
+
+/** A static, non-interactive chip — no role or tabindex is added since no `onClick` is provided. */
+export const Default = meta.story({
+	name: "Default",
+	render: () => (
+		<div class="flex gap-2 font-sans">
+			<Root class={baseClass}>Design</Root>
+			<Root class={baseClass}>Engineering</Root>
+			<Root class={baseClass}>Product</Root>
+		</div>
+	),
+});
+
+/** Passing `onClick` makes the chip keyboard-operable (`role="button"`, focusable, Enter/Space activate it). */
+function ClickableDemo() {
+	const [selected, setSelected] = createSignal<string[]>([]);
+	const options = ["React", "Solid", "Vue", "Svelte"];
+
+	const toggle = (value: string) => {
+		setSelected((prev) =>
+			prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value],
+		);
+	};
+
+	return (
+		<div class="flex flex-wrap gap-2 font-sans">
+			<For each={options}>
+				{(option) => (
+					<Root
+						class={`${baseClass} ${clickableClass} ${
+							selected().includes(option) ? "bg-blue-600 text-white" : ""
+						}`}
+						onClick={() => toggle(option)}
+					>
+						{option}
+					</Root>
+				)}
+			</For>
+		</div>
+	);
+}
+
+export const Clickable = meta.story({
+	name: "Clickable",
+	render: () => <ClickableDemo />,
+});
+
+/** `Chip.Delete` stops its click from bubbling to `Chip.Root`, so removal and selection can coexist. */
+function DeletableDemo() {
+	const [tags, setTags] = createSignal(["urgent", "bug", "frontend"]);
+
+	const remove = (tag: string) => {
+		setTags((prev) => prev.filter((t) => t !== tag));
+	};
+
+	return (
+		<div class="flex flex-wrap gap-2 font-sans">
+			<For each={tags()}>
+				{(tag) => (
+					<Root class={baseClass}>
+						{tag}
+						<Delete
+							class={deleteButtonClass}
+							onClick={() => remove(tag)}
+							aria-label={`Remove ${tag}`}
+						>
+							✕
+						</Delete>
+					</Root>
+				)}
+			</For>
+		</div>
+	);
+}
+
+export const Deletable = meta.story({
+	name: "Deletable",
+	render: () => <DeletableDemo />,
+});
+
+/** `disabled` on `Chip.Root` cascades to a nested `Chip.Delete` automatically. */
+export const Disabled = meta.story({
+	name: "Disabled",
+	render: () => (
+		<div class="flex gap-2 font-sans">
+			<Root class={`${baseClass} ${disabledClass}`} disabled onClick={() => {}}>
+				Archived
+			</Root>
+			<Root class={`${baseClass} ${disabledClass}`} disabled>
+				Archived
+				<Delete class={deleteButtonClass}>✕</Delete>
+			</Root>
+		</div>
+	),
+});
+
+/** Decorators are just children — no dedicated slot component is needed. */
+export const WithDecorators = meta.story({
+	name: "With Decorators",
+	render: () => (
+		<div class="flex gap-2 font-sans">
+			<Root class={baseClass}>
+				<span aria-hidden="true">●</span>
+				Online
+			</Root>
+			<Root class={`${baseClass} ${clickableClass}`} onClick={() => {}}>
+				<span aria-hidden="true">★</span>
+				Favorite
+			</Root>
+		</div>
+	),
+});

--- a/packages/core/src/chip/stories/chip.stories.tsx
+++ b/packages/core/src/chip/stories/chip.stories.tsx
@@ -14,7 +14,7 @@ const baseClass =
 	"inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium bg-slate-100 text-slate-700";
 
 const clickableClass =
-	"data-[clickable]:cursor-pointer data-[clickable]:hover:bg-slate-200 data-[clickable]:focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500";
+	"data-[clickable]:cursor-pointer data-[clickable]:hover:bg-slate-200 data-[clickable]:focus-visible:outline-2 focus-visible:outline-blue-500";
 
 const disabledClass =
 	"data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed";
@@ -84,7 +84,7 @@ function SelectableDemo() {
 			<For each={options}>
 				{(option) => (
 					<Root
-						class={`${baseClass} relative has-[[data-checked]]:bg-blue-600 has-[[data-checked]]:text-white has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-blue-500`}
+						class={`${baseClass} relative has-data-checked:bg-blue-600 has-data-checked:text-white has-focus-visible:outline-2 has-focus-visible:outline-blue-500`}
 					>
 						<Checkbox.Root class="contents">
 							<Checkbox.Input


### PR DESCRIPTION
- Adds a new headless `Chip` component (`@kobalte/core/chip`) — Kobalte didn't previously have a chip/tag primitive. It follows the shape of Joy UI's `Chip`/`ChipDelete`, but stays true to Kobalte's own conventions (data attributes, `translations` i18n pattern, polymorphic `as`) rather than copying MUI's styled implementation.
- `Chip.Root` renders as a static, non-interactive `span` by default and only becomes keyboard-operable (`role="button"`, focusable, `Enter`/`Space` activation, `data-clickable`) once an `onClick` handler is passed — plain display chips never steal a tab stop. When rendered as a real `<button>` (`as="button"`), the native `disabled` attribute is forwarded correctly instead of only using `aria-disabled`.
- `Chip.Delete` composes the existing `Button` primitive (same pattern as `Dialog.CloseButton`/`Toast.CloseButton`/`Popover.CloseButton`), stops its click from bubbling to `Chip.Root`, inherits `disabled` from context, and defaults its `aria-label` from a new `chip.intl.ts` translations file.
- **Selectable/filter chips** are supported the same way MUI Joy's `Chip` does it (confirmed against their docs) — composition with a real `Checkbox`/`Radio`, not a bespoke `selected`/`pressed` prop. A checkbox input is stretched invisibly over the whole chip so it owns real ARIA-checked semantics and keyboard support, while the chip's visual state reacts to the nested `data-checked` attribute purely via the CSS `:has()` selector, with no extra JS. Demonstrated in Storybook (`Selectable` story), the docs (`SelectableExample`, "Selectable chip (filter chips)" section), and covered by the `Features`/`Anatomy` write-up in `chip.mdx`.
- Full unit test coverage (9 tests) and Storybook stories (Default, Clickable, Selectable, Deletable, Disabled, With Decorators).
- Docs page (`chip.mdx`) with anatomy, usage examples (clickable / selectable / disabled chips), API reference, and keyboard interactions, plus a new "Chip" (marked `new`) entry in the docs nav.