### PR TITLE
fix(core): hide outside content with inert to avoid aria-hidden focus warning

### DIFF
--- a/.changeset/aria-hide-outside-inert.md
+++ b/.changeset/aria-hide-outside-inert.md
@@ -1,0 +1,5 @@
+---
+"@kobalte/core": patch
+---
+
+Use `inert` instead of `aria-hidden` when hiding outside content for modal overlays (Dialog, DropdownMenu, Select, Popover, …), when the browser supports it. This resolves the console warning "Blocked aria-hidden on an element because its descendant retained focus" that Chrome logs the first time an overlay opens (the trigger is still focused for a tick before focus moves into the overlay). Falls back to `aria-hidden` when `inert` is unsupported.

--- a/packages/core/src/primitives/create-hide-outside/create-hide-outside.ts
+++ b/packages/core/src/primitives/create-hide-outside/create-hide-outside.ts
@@ -50,6 +50,32 @@ interface ObserverWrapper {
 const refCountMap = new WeakMap<Element, number>();
 const observerStack: Array<ObserverWrapper> = [];
 
+const supportsInert =
+	typeof HTMLElement !== "undefined" && "inert" in HTMLElement.prototype;
+
+// Whether a node is currently hidden from screen readers.
+function getHidden(element: Element) {
+	return supportsInert && element instanceof HTMLElement
+		? element.inert
+		: element.getAttribute("aria-hidden") === "true";
+}
+
+// Hides/shows a node from screen readers. Prefers the `inert` attribute over
+// `aria-hidden` when supported: unlike `aria-hidden`, `inert` also removes the
+// subtree from the focus order, so the browser does not block it (and log
+// "Blocked aria-hidden on an element because its descendant retained focus")
+// during the tick between an overlay opening and focus moving into it. Mirrors
+// @react-aria/overlays' ariaHideOutside, which this file is based on.
+function setHidden(element: Element, hidden: boolean) {
+	if (supportsInert && element instanceof HTMLElement) {
+		element.inert = hidden;
+	} else if (hidden) {
+		element.setAttribute("aria-hidden", "true");
+	} else {
+		element.removeAttribute("aria-hidden");
+	}
+}
+
 /**
  * Hides all elements in the DOM outside the given targets from screen readers using aria-hidden,
  * and returns a function to revert these changes. In addition, changes to the DOM are watched
@@ -116,14 +142,14 @@ export function ariaHideOutside(targets: Element[], root = document.body) {
 	const hide = (node: Element) => {
 		const refCount = refCountMap.get(node) ?? 0;
 
-		// If already aria-hidden, and the ref count is zero, then this element
+		// If already hidden, and the ref count is zero, then this element
 		// was already hidden and there's nothing for us to do.
-		if (node.getAttribute("aria-hidden") === "true" && refCount === 0) {
+		if (getHidden(node) && refCount === 0) {
 			return;
 		}
 
 		if (refCount === 0) {
-			node.setAttribute("aria-hidden", "true");
+			setHidden(node, true);
 		}
 
 		hiddenNodes.add(node);
@@ -197,7 +223,7 @@ export function ariaHideOutside(targets: Element[], root = document.body) {
 			}
 
 			if (count === 1) {
-				node.removeAttribute("aria-hidden");
+				setHidden(node, false);
 				refCountMap.delete(node);
 			} else {
 				refCountMap.set(node, count - 1);


### PR DESCRIPTION
## Summary

Fixes #541 — the console warning Chrome logs the first time any modal overlay opens:

> Blocked aria-hidden on an element because its descendant retained focus. … Consider using the inert attribute instead, which will also prevent focus.

Reproduces on the [official DropdownMenu docs](https://kobalte.dev/docs/core/components/dropdown-menu/) (and, per the thread, on `Dialog`, `Select`, `Popover` — anything that uses `createHideOutside`).

## Root cause

On open, `ariaHideOutside` synchronously walks from `<body>` and sets `aria-hidden="true"` on everything outside the portalled content, including the ancestor of the trigger. But focus is moved into the overlay a tick *later* (deferred autofocus / focus scope). So for one frame the still-focused trigger sits under an `aria-hidden` ancestor, and Chrome blocks it (and logs the warning). It only surfaces once per session because Chrome dedupes the warning against the unchanged ancestor node.

## Fix

Prefer the **`inert`** attribute over `aria-hidden` when the browser supports it — exactly what the warning itself recommends, and what [`@react-aria/overlays`' `ariaHideOutside`](https://github.com/adobe/react-spectrum/blob/main/packages/react-aria/src/overlays/ariaHideOutside.ts) (the file this one is based on) now does. `inert` removes the subtree from the focus order in addition to hiding it from assistive tech, so the browser doesn't block it. Falls back to `aria-hidden` when `inert` is unsupported.

The change is confined to `create-hide-outside.ts`: a `getHidden`/`setHidden` pair replaces the direct `aria-hidden` reads/writes.

## Verification

- **Existing `ariaHideOutside` unit tests: all pass unchanged.** jsdom doesn't implement `inert`, so `supportsInert` is `false` under test and the code takes the `aria-hidden` path — the current assertions still hold. (Real browsers get `inert`.)
- **Browser-tested** against the DropdownMenu docs example (headless Chromium) — before/after this change:
  - ✅ **0** "Blocked aria-hidden…" warnings on first open (was 1).
  - ✅ On open, `#app` receives `inert` (not `aria-hidden`); focus moves into the menu content.
  - ✅ **Focus restore works** — pressing Escape closes the menu and returns focus to the trigger.
  - ✅ **Outside-click dismissal works** — clicking outside still closes the menu; `inert` is fully removed on close.
  - ✅ No new console errors.

## Notes

React Aria gates this behind a `shouldUseInert` option and opts in from its modal overlays. Here I've defaulted it on, since `ariaHideOutside`/`createHideOutside` is only ever used in modal overlay contexts where making the outside inert is the correct, more-robust behavior (and it's verified above not to regress focus restore or outside-dismiss). Happy to instead thread an option through `CreateHideOutsideProps` and opt in per-component if you'd prefer that shape.
