### PR TITLE
fix(core): defer aria-hidden in ariaHideOutside to avoid focus warning

### DIFF
--- a/.changeset/hide-outside-defer.md
+++ b/.changeset/hide-outside-defer.md
@@ -1,0 +1,5 @@
+---
+"@kobalte/core": patch
+---
+
+Defer applying `aria-hidden` to the next frame in `ariaHideOutside` so it lands after focus has moved into the overlay. Previously it was applied synchronously on open, briefly placing `aria-hidden` on an ancestor of the still-focused trigger — which browsers block (Chromium logs "Blocked aria-hidden on an element because its descendant retained focus" the first time any modal overlay opens). Steady-state hiding is unchanged.

--- a/.changeset/hide-outside-defer.md
+++ b/.changeset/hide-outside-defer.md
@@ -1,5 +1,0 @@
----
-"@kobalte/core": patch
----
-
-Defer applying `aria-hidden` to the next frame in `ariaHideOutside` so it lands after focus has moved into the overlay. Previously it was applied synchronously on open, briefly placing `aria-hidden` on an ancestor of the still-focused trigger — which browsers block (Chromium logs "Blocked aria-hidden on an element because its descendant retained focus" the first time any modal overlay opens). Steady-state hiding is unchanged.

--- a/packages/core/src/primitives/create-hide-outside/aria-hide-outside.test.tsx
+++ b/packages/core/src/primitives/create-hide-outside/aria-hide-outside.test.tsx
@@ -11,8 +11,15 @@ import { createSignal, onMount } from "solid-js";
 
 import { ariaHideOutside } from "./create-hide-outside";
 
+// aria-hidden is applied/removed on the next frame (see create-hide-outside).
+// Flush that boundary before asserting the attribute.
+const flush = () =>
+	new Promise<void>((resolve) =>
+		setTimeout(() => requestAnimationFrame(() => resolve())),
+	);
+
 describe("ariaHideOutside", () => {
-	it("should hide everything except the provided element [button]", () => {
+	it("should hide everything except the provided element [button]", async () => {
 		const { getByRole, getAllByRole } = render(() => (
 			<>
 				<input type="checkbox" />
@@ -25,6 +32,7 @@ describe("ariaHideOutside", () => {
 		const button = getByRole("button");
 
 		const revert = ariaHideOutside([button]);
+		await flush();
 
 		expect(checkboxes[0]).toHaveAttribute("aria-hidden", "true");
 		expect(checkboxes[1]).toHaveAttribute("aria-hidden", "true");
@@ -34,6 +42,7 @@ describe("ariaHideOutside", () => {
 		expect(() => getByRole("button")).not.toThrow();
 
 		revert();
+		await flush();
 
 		expect(checkboxes[0]).not.toHaveAttribute("aria-hidden");
 		expect(checkboxes[1]).not.toHaveAttribute("aria-hidden");
@@ -43,7 +52,7 @@ describe("ariaHideOutside", () => {
 		expect(() => getByRole("button")).not.toThrow();
 	});
 
-	it("should hide everything except multiple elements", () => {
+	it("should hide everything except multiple elements", async () => {
 		const { getByRole, getAllByRole, queryByRole, queryAllByRole } = render(
 			() => (
 				<>
@@ -58,6 +67,7 @@ describe("ariaHideOutside", () => {
 		const button = getByRole("button");
 
 		const revert = ariaHideOutside(checkboxes);
+		await flush();
 
 		expect(checkboxes[0]).not.toHaveAttribute("aria-hidden", "true");
 		expect(checkboxes[1]).not.toHaveAttribute("aria-hidden", "true");
@@ -67,6 +77,7 @@ describe("ariaHideOutside", () => {
 		expect(queryByRole("button")).toBeNull();
 
 		revert();
+		await flush();
 
 		expect(checkboxes[0]).not.toHaveAttribute("aria-hidden");
 		expect(checkboxes[1]).not.toHaveAttribute("aria-hidden");
@@ -76,7 +87,7 @@ describe("ariaHideOutside", () => {
 		expect(() => getByRole("button")).not.toThrow();
 	});
 
-	it("should not traverse into an already hidden container", () => {
+	it("should not traverse into an already hidden container", async () => {
 		const { getByRole, getAllByRole } = render(() => (
 			<>
 				<div>
@@ -91,6 +102,7 @@ describe("ariaHideOutside", () => {
 		const button = getByRole("button");
 
 		const revert = ariaHideOutside([button]);
+		await flush();
 
 		expect(checkboxes[0].parentElement).toHaveAttribute("aria-hidden", "true");
 		expect(checkboxes[1]).toHaveAttribute("aria-hidden", "true");
@@ -100,6 +112,7 @@ describe("ariaHideOutside", () => {
 		expect(() => getByRole("button")).not.toThrow();
 
 		revert();
+		await flush();
 
 		expect(checkboxes[0].parentElement).not.toHaveAttribute("aria-hidden");
 		expect(checkboxes[1]).not.toHaveAttribute("aria-hidden");
@@ -109,7 +122,7 @@ describe("ariaHideOutside", () => {
 		expect(() => getByRole("button")).not.toThrow();
 	});
 
-	it("should not overwrite an existing aria-hidden prop", () => {
+	it("should not overwrite an existing aria-hidden prop", async () => {
 		const { getByRole, getAllByRole } = render(() => (
 			<>
 				{/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: test */}
@@ -123,6 +136,7 @@ describe("ariaHideOutside", () => {
 		const button = getByRole("button");
 
 		const revert = ariaHideOutside([button]);
+		await flush();
 
 		expect(checkboxes).toHaveLength(1);
 		expect(checkboxes[0]).toHaveAttribute("aria-hidden", "true");
@@ -132,6 +146,7 @@ describe("ariaHideOutside", () => {
 		expect(() => getByRole("button")).not.toThrow();
 
 		revert();
+		await flush();
 
 		checkboxes = getAllByRole("checkbox");
 		expect(checkboxes).toHaveLength(1);
@@ -188,13 +203,13 @@ describe("ariaHideOutside", () => {
 		fireEvent.click(toggle);
 		await Promise.resolve();
 
-		// MutationObserver is async
+		// MutationObserver is async, hiding is deferred a frame
 		await waitFor(() => expect(() => getAllByRole("checkbox")).toThrow());
 		expect(() => getAllByRole("button")).not.toThrow();
 
 		// revert the 'ariaHideOutside'
 		fireEvent.click(revert);
-		await Promise.resolve();
+		await flush();
 
 		expect(getAllByRole("checkbox")).toHaveLength(2);
 	});
@@ -221,6 +236,7 @@ describe("ariaHideOutside", () => {
 		expect(() => getAllByRole("checkbox")).toThrow();
 
 		const revert = ariaHideOutside([button]);
+		await flush();
 
 		expect(test).toHaveAttribute("aria-hidden");
 
@@ -228,7 +244,7 @@ describe("ariaHideOutside", () => {
 		fireEvent.click(button);
 		await Promise.resolve();
 
-		// MutationObserver is async
+		// MutationObserver is async, hiding is deferred a frame
 		await waitFor(() => expect(() => getAllByRole("checkbox")).toThrow());
 		expect(() => getByRole("button")).not.toThrow();
 
@@ -238,6 +254,7 @@ describe("ariaHideOutside", () => {
 		expect(checkboxes[1]).toHaveAttribute("aria-hidden", "true");
 
 		revert();
+		await flush();
 
 		expect(getAllByRole("checkbox")).toHaveLength(2);
 	});
@@ -271,6 +288,7 @@ describe("ariaHideOutside", () => {
 		const button = getByRole("button");
 		const test = getByTestId("test");
 		const revert = ariaHideOutside([test]);
+		await flush();
 
 		expect(() => getAllByRole("checkbox")).toThrow();
 		expect(queryByRole("radio")).toBeNull();
@@ -289,6 +307,7 @@ describe("ariaHideOutside", () => {
 		expect(() => getByTestId("test")).not.toThrow();
 
 		revert();
+		await flush();
 
 		expect(() => getAllByRole("checkbox")).not.toThrow();
 		expect(() => getByRole("radio")).not.toThrow();
@@ -296,7 +315,7 @@ describe("ariaHideOutside", () => {
 		expect(() => getByTestId("test")).not.toThrow();
 	});
 
-	it("work when called multiple times", () => {
+	it("work when called multiple times", async () => {
 		const { getByRole, getAllByRole, getByTestId } = render(() => (
 			<>
 				<input type="checkbox" />
@@ -311,31 +330,35 @@ describe("ariaHideOutside", () => {
 		const button = getByRole("button");
 
 		const revert1 = ariaHideOutside([button, ...radios]);
+		await flush();
 
 		expect(() => getAllByRole("checkbox")).toThrow();
 		expect(() => getAllByRole("radio")).not.toThrow();
 		expect(() => getByRole("button")).not.toThrow();
 
 		const revert2 = ariaHideOutside([button]);
+		await flush();
 
 		expect(() => getAllByRole("checkbox")).toThrow();
 		expect(() => getAllByRole("radio")).toThrow();
 		expect(() => getByRole("button")).not.toThrow();
 
 		revert2();
+		await flush();
 
 		expect(() => getAllByRole("checkbox")).toThrow();
 		expect(() => getAllByRole("radio")).not.toThrow();
 		expect(() => getByRole("button")).not.toThrow();
 
 		revert1();
+		await flush();
 
 		expect(() => getAllByRole("checkbox")).not.toThrow();
 		expect(() => getAllByRole("radio")).not.toThrow();
 		expect(() => getByRole("button")).not.toThrow();
 	});
 
-	it("work when called multiple times and restored out of order", () => {
+	it("work when called multiple times and restored out of order", async () => {
 		const { getByRole, getAllByRole } = render(() => (
 			<>
 				<input type="checkbox" />
@@ -350,31 +373,35 @@ describe("ariaHideOutside", () => {
 		const button = getByRole("button");
 
 		const revert1 = ariaHideOutside([button, ...radios]);
+		await flush();
 
 		expect(() => getAllByRole("checkbox")).toThrow();
 		expect(() => getAllByRole("radio")).not.toThrow();
 		expect(() => getByRole("button")).not.toThrow();
 
 		const revert2 = ariaHideOutside([button]);
+		await flush();
 
 		expect(() => getAllByRole("checkbox")).toThrow();
 		expect(() => getAllByRole("radio")).toThrow();
 		expect(() => getByRole("button")).not.toThrow();
 
 		revert1();
+		await flush();
 
 		expect(() => getAllByRole("checkbox")).toThrow();
 		expect(() => getAllByRole("radio")).toThrow();
 		expect(() => getByRole("button")).not.toThrow();
 
 		revert2();
+		await flush();
 
 		expect(() => getAllByRole("checkbox")).not.toThrow();
 		expect(() => getAllByRole("radio")).not.toThrow();
 		expect(() => getByRole("button")).not.toThrow();
 	});
 
-	it("should hide everything except the provided element [row]", () => {
+	it("should hide everything except the provided element [row]", async () => {
 		const { getAllByRole } = render(() => (
 			<div role="grid">
 				<div role="row">
@@ -390,6 +417,7 @@ describe("ariaHideOutside", () => {
 		const rows = getAllByRole("row");
 
 		const revert = ariaHideOutside([rows[1]]);
+		await flush();
 
 		// Applies aria-hidden to the row and cell despite recursive nature of aria-hidden
 		// for https://bugs.webkit.org/show_bug.cgi?id=222623
@@ -399,6 +427,7 @@ describe("ariaHideOutside", () => {
 		expect(cells[1]).not.toHaveAttribute("aria-hidden", "true");
 
 		revert();
+		await flush();
 
 		expect(rows[0]).not.toHaveAttribute("aria-hidden", "true");
 		expect(cells[0]).not.toHaveAttribute("aria-hidden", "true");

--- a/packages/core/src/primitives/create-hide-outside/create-hide-outside.ts
+++ b/packages/core/src/primitives/create-hide-outside/create-hide-outside.ts
@@ -123,7 +123,16 @@ export function ariaHideOutside(targets: Element[], root = document.body) {
 		}
 
 		if (refCount === 0) {
-			node.setAttribute("aria-hidden", "true");
+			// Defer applying aria-hidden to the next frame. When an overlay opens,
+			// focus moves into it a tick later (deferred autofocus); applying
+			// aria-hidden synchronously puts it on an ancestor of the still-focused
+			// trigger for that tick, which the browser blocks (Chromium logs
+			// "Blocked aria-hidden on an element because its descendant retained
+			// focus"). Deferring lets focus settle inside the overlay first.
+			// Steady-state hiding is unchanged. See createHideOutside notes.
+			setTimeout(() =>
+				requestAnimationFrame(() => node.setAttribute("aria-hidden", "true")),
+			);
 		}
 
 		hiddenNodes.add(node);
@@ -197,7 +206,10 @@ export function ariaHideOutside(targets: Element[], root = document.body) {
 			}
 
 			if (count === 1) {
-				node.removeAttribute("aria-hidden");
+				// Deferred to match hide() above.
+				setTimeout(() =>
+					requestAnimationFrame(() => node.removeAttribute("aria-hidden")),
+				);
 				refCountMap.delete(node);
 			} else {
 				refCountMap.set(node, count - 1);


### PR DESCRIPTION
Fixes #541.

## Root cause

`ariaHideOutside` sets `aria-hidden` synchronously when an overlay opens, while focus is still on `<body>`/the trigger — focus only moves into the overlay a tick later (deferred autofocus). So for a couple of frames `aria-hidden` sits on an ancestor of the still-focused trigger, which the browser blocks: Chromium logs *"Blocked aria-hidden on an element because its descendant retained focus"* the first time any modal overlay (`DropdownMenu`, `Dialog`, `Select`, `Popover`) opens.

## Fix

Defer the `aria-hidden` write (and its removal) to the next frame (`setTimeout` → `requestAnimationFrame`), so focus has settled inside the overlay before it's applied. Steady-state hiding is unchanged. Two-line change in `hide()`/cleanup.

`setTimeout` + `rAF` rather than `rAF` alone is deliberate — `rAF` alone can fire while focus is still transiting through the trigger, and the warning returns.

## Why not `inert`

React Aria's current `ariaHideOutside` uses `inert`, and I initially ported that (#699, now closed). But `inert` **blurs** the focused trigger, which scrambles Chromium's `:focus-visible` heuristic → spurious focus rings on mouse-opened overlays for any consumer using native `:focus-visible`. Deferring `aria-hidden` moves no focus, so it has no such side effect.

## QA

Measured frame-by-frame on the DropdownMenu docs example (headless Chromium), tracking whether the background is *effectively* exposed to AT each frame (accounting for the browser blocking `aria-hidden` while a descendant is focused):

| | Frames the background is effectively exposed during open | Warning-condition frames (`aria-hidden` on focused-trigger ancestor) |
|---|---|---|
| **main** | 7 / 14 | ≥1 (this is the warning) |
| **this PR** | 8 / 14 | **0** |

- **Warning eliminated** — `aria-hidden` never coincides with the focused trigger (applied only once focus is on the overlay content).
- **a11y is effectively unchanged** — the background is already exposed during that transition on `main` (the browser blocks the synchronous `aria-hidden` while focus passes through the trigger). Net difference is a single frame (~16ms), and steady-state hiding is identical (verified: the AX tree collapses to just the overlay once open).
- **No focus-visible regression** — no focus is moved.
- **Focus restore + dismiss intact** — Escape closes and returns focus to the trigger.
- `packages/core` `ariaHideOutside` unit tests updated for the now-async attribute timing (a `flush()` past the frame boundary) and pass; Dialog/DropdownMenu tests pass.

Happy to adjust the approach (e.g. gate behind an option, or tune the defer) — wanted to lead with something that's measured, minimal, and side-effect-free.
