### PR TITLE
fix(color-mode): `createEffect` split for solid2

### DIFF
--- a/packages/core/src/color-mode/color-mode-provider.tsx
+++ b/packages/core/src/color-mode/color-mode-provider.tsx
@@ -65,10 +65,10 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
 	};
 
 	createEffect(
-		() => colorModeManager().get() ?? fallbackColorMode(), 
+		() => colorModeManager().get() ?? fallbackColorMode(),
 		(mode) => {
 			setColorMode(mode);
-		}
+		},
 	);
 
 	onCleanup(() => {

--- a/packages/core/src/color-mode/color-mode-provider.tsx
+++ b/packages/core/src/color-mode/color-mode-provider.tsx
@@ -64,9 +64,12 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
 		setColorMode(colorMode() === "dark" ? "light" : "dark");
 	};
 
-	createEffect(() => {
-		setColorMode(colorModeManager().get() ?? fallbackColorMode());
-	});
+	createEffect(
+		() => colorModeManager().get() ?? fallbackColorMode(), 
+		(mode) => {
+			setColorMode(mode);
+		}
+	);
 
 	onCleanup(() => {
 		// ensure listener is always cleaned when component is destroyed.


### PR DESCRIPTION
Fix `createEffect` being called with too few arguments.