### PR TITLE
fix(core): preserve aria-hidden during modal handoff

### DIFF
--- a/.changeset/big-shirts-grab.md
+++ b/.changeset/big-shirts-grab.md
@@ -1,0 +1,5 @@
+---
+"@kobalte/core": patch
+---
+
+fix: preserve aria-hidden during modal handoff

--- a/packages/core/src/primitives/create-hide-outside/aria-hide-outside.test.tsx
+++ b/packages/core/src/primitives/create-hide-outside/aria-hide-outside.test.tsx
@@ -401,6 +401,34 @@ describe("ariaHideOutside", () => {
 		expect(() => getByRole("button")).not.toThrow();
 	});
 
+	it("keeps elements hidden during an immediate ownership handoff", async () => {
+		const { getByRole } = render(() => (
+			<>
+				<input type="checkbox" />
+				<button type="button">Button</button>
+			</>
+		));
+
+		const checkbox = getByRole("checkbox");
+		const button = getByRole("button");
+
+		const revert1 = ariaHideOutside([button]);
+		await flush();
+
+		expect(checkbox).toHaveAttribute("aria-hidden", "true");
+
+		revert1();
+		const revert2 = ariaHideOutside([button]);
+		await flush();
+
+		expect(checkbox).toHaveAttribute("aria-hidden", "true");
+
+		revert2();
+		await flush();
+
+		expect(checkbox).not.toHaveAttribute("aria-hidden");
+	});
+
 	it("should hide everything except the provided element [row]", async () => {
 		const { getAllByRole } = render(() => (
 			<div role="grid">

--- a/packages/core/src/primitives/create-hide-outside/create-hide-outside.ts
+++ b/packages/core/src/primitives/create-hide-outside/create-hide-outside.ts
@@ -206,11 +206,20 @@ export function ariaHideOutside(targets: Element[], root = document.body) {
 			}
 
 			if (count === 1) {
-				// Deferred to match hide() above.
+				// Deferred to match hide() above. Keep the final reference until this
+				// runs so another call can acquire it before aria-hidden is removed.
 				setTimeout(() =>
-					requestAnimationFrame(() => node.removeAttribute("aria-hidden")),
+					requestAnimationFrame(() => {
+						const currentCount = refCountMap.get(node);
+
+						if (currentCount === 1) {
+							node.removeAttribute("aria-hidden");
+							refCountMap.delete(node);
+						} else if (currentCount != null && currentCount > 1) {
+							refCountMap.set(node, currentCount - 1);
+						}
+					}),
 				);
-				refCountMap.delete(node);
 			} else {
 				refCountMap.set(node, count - 1);
 			}


### PR DESCRIPTION
Fixes #720 

## Summary

- Preserve hide-outside ownership until deferred cleanup executes.
- Prevent an earlier modal from unhiding the application after a new modal acquires ownership.
- Add a regression test for immediate ownership handoff.