### PR TITLE
fix: resolve interact-outside targets across shadow boundaries

### DIFF
--- a/.changeset/nervous-donkeys-invite.md
+++ b/.changeset/nervous-donkeys-invite.md
@@ -1,0 +1,5 @@
+---
+"@kobalte/core": patch
+---
+
+fix: resolve interact-outside targets across shadow boundaries

--- a/packages/core/src/dismissable-layer/dismissable-layer.test.tsx
+++ b/packages/core/src/dismissable-layer/dismissable-layer.test.tsx
@@ -1,0 +1,103 @@
+import { createPointerEvent } from "@kobalte/tests";
+import { fireEvent } from "@solidjs/testing-library";
+import { render } from "solid-js/web";
+import { vi } from "vitest";
+
+import { DismissableLayer } from "./dismissable-layer";
+
+describe("DismissableLayer", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.clearAllTimers();
+	});
+
+	describe("Shadow DOM", () => {
+		/**
+		 * The shape of #445: a layer and its trigger both rendered inside a shadow root.
+		 *
+		 * `createInteractOutside` listens on the document, so `event.target` is retargeted to the
+		 * shadow host. The host matches neither `excludedElements` nor the layer itself, so both the
+		 * trigger and the layer's own content read as "outside" and the layer dismissed itself on
+		 * pointerdown — which is what makes a `Select` trigger close and immediately reopen its
+		 * dropdown, and what makes clicking an item dismiss the layer before the item can activate.
+		 */
+		const setupShadowTest = () => {
+			const onDismiss = vi.fn();
+
+			const host = document.createElement("div");
+			document.body.appendChild(host);
+			const shadowRoot = host.attachShadow({ mode: "open" });
+
+			let trigger!: HTMLButtonElement;
+			let content!: HTMLSpanElement;
+			let outside!: HTMLButtonElement;
+
+			const dispose = render(
+				() => (
+					<>
+						<button ref={trigger} type="button">
+							Trigger
+						</button>
+						<button ref={outside} type="button">
+							Outside
+						</button>
+						<DismissableLayer
+							excludedElements={[() => trigger]}
+							onDismiss={onDismiss}
+						>
+							<span ref={content}>Content</span>
+						</DismissableLayer>
+					</>
+				),
+				shadowRoot,
+			);
+
+			// `createInteractOutside` defers registering its pointerdown listener by a tick.
+			vi.runAllTimers();
+
+			onTestFinished(() => {
+				dispose();
+				host.remove();
+			});
+
+			return { onDismiss, trigger, content, outside };
+		};
+
+		it("should not dismiss when interacting with an excluded trigger inside a shadow root", () => {
+			const { onDismiss, trigger } = setupShadowTest();
+
+			fireEvent(
+				trigger,
+				createPointerEvent("pointerdown", { bubbles: true, composed: true }),
+			);
+
+			expect(onDismiss).not.toHaveBeenCalled();
+		});
+
+		it("should not dismiss when interacting with the layer's own content inside a shadow root", () => {
+			const { onDismiss, content } = setupShadowTest();
+
+			fireEvent(
+				content,
+				createPointerEvent("pointerdown", { bubbles: true, composed: true }),
+			);
+
+			expect(onDismiss).not.toHaveBeenCalled();
+		});
+
+		it("should still dismiss when interacting outside the layer inside a shadow root", () => {
+			const { onDismiss, outside } = setupShadowTest();
+
+			fireEvent(
+				outside,
+				createPointerEvent("pointerdown", { bubbles: true, composed: true }),
+			);
+
+			expect(onDismiss).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/core/src/primitives/create-interact-outside/create-interact-outside.test.tsx
+++ b/packages/core/src/primitives/create-interact-outside/create-interact-outside.test.tsx
@@ -1,6 +1,6 @@
 import { createPointerEvent, installPointerEvent } from "@kobalte/tests";
 import { fireEvent, render } from "@solidjs/testing-library";
-import type { JSX } from "solid-js";
+import { type JSX, createRoot } from "solid-js";
 
 import {
 	type CreateInteractOutsideProps,
@@ -194,6 +194,93 @@ describe("createInteractOutside", () => {
 				expect(mocks.onPointerDownOutside).not.toHaveBeenCalled();
 				expect(mocks.onInteractOutside).not.toHaveBeenCalled();
 			});
+		});
+	});
+
+	describe("Shadow DOM", () => {
+		/**
+		 * A layer whose content lives inside a shadow root — what happens when a portal target is
+		 * itself shadowed, rather than being in the light DOM.
+		 *
+		 * These listeners are on the document, so `event.target` is retargeted to the shadow host.
+		 * The host is an *ancestor* of the layer, so `contains(layer, host)` is false and every
+		 * interaction with the layer's own content read as "outside": the layer dismissed itself on
+		 * pointerdown, the content unmounted, and pointerup never landed on anything. The symptom is
+		 * a menu that closes when you click an item, without the item ever activating.
+		 */
+		const setupShadowTest = () => {
+			const onFocusOutside = vi.fn();
+			const onPointerDownOutside = vi.fn();
+			const onInteractOutside = vi.fn();
+
+			const host = document.createElement("div");
+			document.body.appendChild(host);
+			const shadowRoot = host.attachShadow({ mode: "open" });
+
+			// The layer (what `ref()` returns) and a child of it — clicking the child is the case
+			// that broke, since only the child is deep enough for retargeting to matter.
+			const inside = document.createElement("div");
+			const insideChild = document.createElement("span");
+			inside.appendChild(insideChild);
+			shadowRoot.appendChild(inside);
+
+			// A sibling in the same shadow root: genuinely outside the layer, and must stay so.
+			const outside = document.createElement("div");
+			shadowRoot.appendChild(outside);
+
+			const dispose = createRoot((disposer) => {
+				createInteractOutside(
+					{ onFocusOutside, onPointerDownOutside, onInteractOutside },
+					() => inside,
+				);
+
+				return disposer;
+			});
+
+			vi.runAllTimers();
+
+			onTestFinished(() => {
+				dispose();
+				host.remove();
+			});
+
+			return {
+				mocks: { onFocusOutside, onPointerDownOutside, onInteractOutside },
+				elements: { inside, insideChild, outside },
+			};
+		};
+
+		it("should NOT trigger when clicking the layer's own content inside a shadow root", () => {
+			const { mocks, elements } = setupShadowTest();
+
+			fireEvent(
+				elements.insideChild,
+				createPointerEvent("pointerdown", { bubbles: true, composed: true }),
+			);
+
+			expect(mocks.onPointerDownOutside).not.toHaveBeenCalled();
+			expect(mocks.onInteractOutside).not.toHaveBeenCalled();
+		});
+
+		it("should still trigger when clicking a sibling inside the same shadow root", () => {
+			const { mocks, elements } = setupShadowTest();
+
+			fireEvent(
+				elements.outside,
+				createPointerEvent("pointerdown", { bubbles: true, composed: true }),
+			);
+
+			expect(mocks.onPointerDownOutside).toHaveBeenCalledTimes(1);
+			expect(mocks.onInteractOutside).toHaveBeenCalledTimes(1);
+		});
+
+		it("should NOT trigger when focus moves to the layer's own content inside a shadow root", () => {
+			const { mocks, elements } = setupShadowTest();
+
+			fireEvent.focusIn(elements.insideChild, { composed: true });
+
+			expect(mocks.onFocusOutside).not.toHaveBeenCalled();
+			expect(mocks.onInteractOutside).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/core/src/primitives/create-interact-outside/create-interact-outside.ts
+++ b/packages/core/src/primitives/create-interact-outside/create-interact-outside.ts
@@ -16,7 +16,6 @@ import {
 	type MaybeAccessor,
 	access,
 	composeEventHandlers,
-	contains,
 	getDocument,
 	isCtrlKey,
 	noop,
@@ -25,6 +24,7 @@ import { type Accessor, createEffect, onCleanup } from "solid-js";
 import { isServer } from "solid-js/web";
 
 import { DATA_TOP_LAYER_ATTR } from "../../dismissable-layer/layer-stack";
+import { closestComposed, containsComposed, getEventTarget } from "./utils";
 
 type EventDetails<T> = {
 	originalEvent: T;
@@ -83,22 +83,27 @@ export function createInteractOutside<T extends Element>(
 		props.onInteractOutside?.(e);
 
 	const isEventOutside = (e: Event) => {
-		const target = e.target as Element | null;
+		// The element the interaction started on, not `e.target` — these listeners
+		// are on the document, so an interaction inside a shadow tree reports that
+		// tree's host instead. The distinction decides this function: a layer
+		// rendered inside a shadow root sees each of its own clicks as the host,
+		// which is outside itself, and dismisses on pointerdown.
+		const target = getEventTarget(e);
 
-		if (!(target instanceof Element)) {
+		if (!target) {
 			return false;
 		}
 
 		// If the target is within a top layer element (e.g. toasts), ignore.
-		if (target.closest(`[${DATA_TOP_LAYER_ATTR}]`)) {
+		if (closestComposed(target, `[${DATA_TOP_LAYER_ATTR}]`)) {
 			return false;
 		}
 
-		if (!contains(ownerDocument(), target)) {
+		if (!containsComposed(ownerDocument(), target)) {
 			return false;
 		}
 
-		if (contains(ref(), target)) {
+		if (containsComposed(ref(), target)) {
 			return false;
 		}
 
@@ -108,7 +113,7 @@ export function createInteractOutside<T extends Element>(
 	const onPointerDown = (e: PointerEvent) => {
 		function handler() {
 			const container = ref();
-			const target = e.target as Element | null;
+			const target = getEventTarget(e);
 
 			if (!container || !target || !isEventOutside(e)) {
 				return;
@@ -161,7 +166,7 @@ export function createInteractOutside<T extends Element>(
 
 	const onFocusIn = (e: FocusEvent) => {
 		const container = ref();
-		const target = e.target as Element | null;
+		const target = getEventTarget(e);
 
 		if (!container || !target || !isEventOutside(e)) {
 			return;

--- a/packages/core/src/primitives/create-interact-outside/utils.ts
+++ b/packages/core/src/primitives/create-interact-outside/utils.ts
@@ -1,0 +1,69 @@
+import { contains } from "@kobalte/utils";
+
+/**
+ * The element an event actually originated from.
+ *
+ * `event.target` is retargeted at every shadow boundary the event crosses, so a
+ * listener on the document reports the outermost shadow *host* rather than the
+ * element that was interacted with. `composedPath()[0]` is that element; for an
+ * event that crosses no boundary the two are identical.
+ */
+export function getEventTarget(event: Event): Element | null {
+	const path =
+		typeof event.composedPath === "function" ? event.composedPath() : undefined;
+	const target = path?.[0] ?? event.target;
+
+	return target instanceof Element ? target : null;
+}
+
+/**
+ * Like `contains`, but able to see through shadow boundaries.
+ *
+ * `Node.prototype.contains` only walks the node tree it is called on, so it
+ * answers `false` for a `child` that lives inside a shadow root — including
+ * `document.contains(elementInAShadowRoot)`. When this walk reaches the top of a
+ * shadow tree it continues from that tree's host, which is how a containment
+ * question about the *rendered* page, rather than one node tree, is answered.
+ */
+export function containsComposed(parent: Node | undefined, child: Node | null) {
+	if (!parent) {
+		return false;
+	}
+
+	let node: Node | null = child;
+
+	while (node) {
+		if (contains(parent, node)) {
+			return true;
+		}
+
+		const root = node.getRootNode();
+		node = root instanceof ShadowRoot ? root.host : null;
+	}
+
+	return false;
+}
+
+/**
+ * Like `Element.prototype.closest`, but able to see through shadow boundaries — it continues from
+ * the host when it reaches the top of a shadow tree, so an ancestor in an outer tree is still found.
+ */
+export function closestComposed(
+	element: Element | null,
+	selector: string,
+): Element | null {
+	let node: Element | null = element;
+
+	while (node) {
+		const match = node.closest(selector);
+
+		if (match) {
+			return match;
+		}
+
+		const root = node.getRootNode();
+		node = root instanceof ShadowRoot ? root.host : null;
+	}
+
+	return null;
+}

--- a/packages/tests/src/utils.ts
+++ b/packages/tests/src/utils.ts
@@ -67,7 +67,16 @@ export function installPointerEvent() {
 }
 
 export function createPointerEvent(type: any, opts: any) {
-	const evt = new Event(type, { bubbles: true, cancelable: true });
+	// `bubbles`, `cancelable` and `composed` are read-only on `Event`, so they have to go through
+	// the constructor rather than the `Object.assign` below.
+	const { bubbles, cancelable, composed, ...rest } = opts ?? {};
+
+	const evt = new Event(type, {
+		bubbles: bubbles ?? true,
+		cancelable: cancelable ?? true,
+		composed: composed ?? false,
+	});
+
 	Object.assign(
 		evt,
 		{
@@ -79,7 +88,7 @@ export function createPointerEvent(type: any, opts: any) {
 			width: 1,
 			height: 1,
 		},
-		opts,
+		rest,
 	);
 	return evt;
 }


### PR DESCRIPTION
## Problem

Closes #445.

`createInteractOutside` registers its `pointerdown` / `focusin` listeners on the document. Events crossing a shadow boundary are retargeted, so by the time they reach a document listener `event.target` is the outermost shadow **host**, not the element that was actually interacted with.

That breaks every containment check in the primitive. A layer rendered inside a shadow root sees each of its own clicks reported as the host — which is an *ancestor* of the layer, not a descendant — so `contains(ref(), target)` is `false` and the layer treats its own content as "outside". It dismisses on `pointerdown`, the content unmounts, and `pointerup` never lands on anything. The symptom is a menu that closes when you click an item, without the item ever activating.

This is the root cause @derekrjones identified in [#445](https://github.com/kobaltedev/kobalte/issues/445):

> `Select` (and many other components) have `DismissableLayer` with `excludedElements={[context.triggerRef]}`. When open, and mousedown on the trigger, it tests if the trigger contains the event target and aborts if so. But when clicking within the shadowdom, **the event target is the shadow host not the trigger**. So the popup is closed, and then trigger opens it again.

## Fix

Three small composed-tree helpers, used by `createInteractOutside`:

- `getEventTarget(event)` — `composedPath()[0]` instead of `event.target`. For an event that crosses no shadow boundary the two are identical, so this is a no-op outside shadow DOM.
- `containsComposed(parent, child)` — like `contains`, but continues from the host when the walk reaches the top of a shadow tree. Needed because `Node.prototype.contains` only walks one node tree; even `document.contains(elementInAShadowRoot)` is `false`.
- `closestComposed(element, selector)` — same idea for `closest`, so the `data-top-layer` lookup still finds an ancestor in an outer tree.

Because `isEventOutside` now resolves the real target before calling `shouldExcludeElement`, this also fixes the `excludedElements` path in `DismissableLayer` — the trigger and nested layers — which is the specific mechanism behind the Select reopen loop.

## Tests

**At the primitive level** (`create-interact-outside`), three cases:

- clicking the layer's own content inside a shadow root must **not** trigger — fails on `main`
- focus moving into the layer's own content inside a shadow root must **not** trigger — fails on `main`
- clicking a *sibling* in the same shadow root must **still** trigger — passes on `main`, included as a regression guard so the fix can't over-correct into never dismissing

**At the `DismissableLayer` level**, three more — this is the path #445 actually reports, with the trigger passed via `excludedElements`:

- pointerdown on the excluded trigger inside a shadow root must **not** dismiss — fails on `main`, and this is precisely the Select reopen loop
- pointerdown on the layer's own content inside a shadow root must **not** dismiss — fails on `main`
- pointerdown genuinely outside the layer must **still** dismiss — passes on `main`, regression guard

I added the second group because the primitive-level tests pin the retargeting behaviour but don't demonstrate the reported symptom. `DismissableLayer` is shared by Select, Combobox, Popover, Menu and Dialog, so covering it exercises the reported component and its siblings at once. A test against `Select` directly wasn't an option — that suite is `describe.skip`ped in this repo (and currently fails 42/57 if unskipped, unrelated to this change).

`createPointerEvent` in `@kobalte/tests` needed a small change to support these: it built the event and then `Object.assign`-ed the options onto it, but `bubbles`, `cancelable` and `composed` are read-only on `Event`, so they have to go through the constructor. `composed: true` is essential here — without it the event never crosses the shadow boundary at all. Defaults are unchanged (`bubbles: true`, `cancelable: true`, `composed: false`) and no existing caller passes any of the three, so every current use is unaffected.

## One thing I'd like your call on: where these helpers live

I put them in `packages/core/src/primitives/create-interact-outside/utils.ts`, but they're generic DOM utilities and `packages/utils/src/dom.ts` — right next to `contains` — is arguably their proper home. I started there and moved them, for a reason worth flagging:

`packages/core` depends on `"@kobalte/utils": "^0.9.2"`, a registry range rather than `workspace:*`, and the committed lockfile resolves it to the published tarball. pnpm 11 also no longer reads `link-workspace-packages` from `.npmrc` (that setting moved to `pnpm-workspace.yaml`, where it isn't set). So `packages/core` builds and tests against the **published** `@kobalte/utils`, not the one in this repo. Anything added to `packages/utils` is invisible to core until utils is released — putting the helpers there made the whole `create-interact-outside` test file fail with `getEventTarget is not a function`.

That looked like it might be unintentional, so I kept this PR to a single package rather than touching dependency wiring. But if you'd prefer the helpers in `packages/utils` I'm glad to redo it that way — it'd mean switching core to `workspace:^` (and a changeset covering both packages), which is a bigger change than a bug fix should smuggle in, especially with `@kobalte/utils@2.0.0-alpha.0` out there. Happy to split that into its own PR instead if it's something you want fixed.

## Verification

- `create-interact-outside` + `dismissable-layer` suites: 25/25 pass; the four new "should not" tests all fail against the parent commit
- full `@kobalte/core` suite otherwise unchanged (`tabs`, `number-field` and `toggle-group` flake intermittently on `main` independently of this PR — which is presumably why CI already wraps `pnpm test` in `nick-fields/retry`)
- `biome check` clean
- `pnpm -F @kobalte/core build` succeeds
