### PR TITLE
fix: avoid STRICT_READ_UNTRACKED in effect callbacks

### DIFF
--- a/packages/core/src/primitives/create-dom-collection/utils.ts
+++ b/packages/core/src/primitives/create-dom-collection/utils.ts
@@ -7,7 +7,7 @@
  */
 
 import { getDocument } from "@kobalte/utils";
-import { type Accessor, createEffect, onCleanup } from "solid-js";
+import { type Accessor, createEffect, onCleanup, untrack } from "solid-js";
 
 import type { DomCollectionItem } from "./types";
 
@@ -122,7 +122,7 @@ function createTimeoutObserver<T extends DomCollectionItem = DomCollectionItem>(
 ) {
 	createEffect(() => {
 		const timeout = setTimeout(() => {
-			setItemsBasedOnDOMPosition(items(), setItems);
+			setItemsBasedOnDOMPosition(untrack(() => items()), setItems);
 		});
 
 		onCleanup(() => clearTimeout(timeout));
@@ -143,21 +143,21 @@ export function createSortBasedOnDOMPosition<
 	createEffect(() => {
 		const callback = () => {
 			const hasPreviousItems = !!previousItems.length;
-			previousItems = items();
+			previousItems = untrack(() => items());
 
 			// We don't want to sort items if items have been just registered.
 			if (!hasPreviousItems) {
 				return;
 			}
 
-			setItemsBasedOnDOMPosition(items(), setItems);
+			setItemsBasedOnDOMPosition(untrack(() => items()), setItems);
 		};
 
-		const root = getCommonParent(items());
+		const root = getCommonParent(untrack(() => items()));
 		const observer = new IntersectionObserver(callback, { root });
 
-		for (const item of items()) {
-			const itemEl = item.ref();
+		for (const item of untrack(() => items())) {
+			const itemEl = untrack(() => item.ref());
 
 			if (itemEl) {
 				observer.observe(itemEl);

--- a/packages/core/src/tabs/tabs-indicator.tsx
+++ b/packages/core/src/tabs/tabs-indicator.tsx
@@ -12,6 +12,7 @@ import {
 	createSignal,
 	on,
 	splitProps,
+	untrack,
 } from "solid-js";
 
 import type { Orientation } from "@kobalte/utils";
@@ -99,8 +100,8 @@ export function TabsIndicator<T extends ValidComponent = "div">(
 		on(
 			[context.selectedTab, context.orientation, direction],
 			() => {
-				if (style() != null) {
-					computeStyle();
+				if (untrack(() => style()) != null) {
+					untrack(() => computeStyle());
 				}
 			},
 			{ defer: true },
@@ -114,7 +115,7 @@ export function TabsIndicator<T extends ValidComponent = "div">(
 	createResizeObserver(context.selectedTab, (_, t) => {
 		if (prevTarget !== t) {
 			prevTarget = t;
-			computeStyle();
+			untrack(() => computeStyle());
 			return;
 		}
 
@@ -128,7 +129,7 @@ export function TabsIndicator<T extends ValidComponent = "div">(
 			setResizing(false);
 		}, 1);
 
-		computeStyle();
+		untrack(() => computeStyle());
 	});
 
 	return (


### PR DESCRIPTION
Fixes `STRICT_READ_UNTRACKED` warnings in Solid 2.0 strict mode.

### Problem
Dev warns:

```
[STRICT_READ_UNTRACKED] Reactive value read directly in an effect callback will not update.
```

Sites:
- `src/primitives/create-dom-collection/utils.ts` — `createTimeoutObserver` and `createSortBasedOnDOMPosition` read `items()`/`item.ref()` in effect/observer callbacks. These are one-time DOM-position setup; `currentItems` param already drives the effect.
- `src/tabs/tabs-indicator.tsx` — `computeStyle()` reads `selectedTab`, `direction`, `orientation`, `style()` inside `on([selectedTab, orientation, direction], ...)` and `createResizeObserver` callbacks. Deps are already tracked via `on(...)`, inner reads should be untracked.

Related: #717 (same Solid 2 hydration strictness that broke `Button`/`Polymorphic` via `Dynamic`).

### Fix
Wrap one-time reads in `untrack()`:

- `create-dom-collection/utils.ts`: `untrack(() => items())`, `untrack(() => item.ref())`
- `tabs-indicator.tsx`: `untrack(() => computeStyle())` / `untrack(() => style())`

Effect still re-runs when tracked deps change (`on(...)` deps or `currentItems`), but inner reads no longer warn.

### Repro
SSR + hydrate any page with `Tabs` (or `List` via `createDomCollection`). Before: warnings. After: 0, hydration `PASS`.
