### PR TITLE
fix: avoid STRICT_READ_UNTRACKED in effect callbacks

### DIFF
--- a/packages/core/src/primitives/create-dom-collection/utils.ts
+++ b/packages/core/src/primitives/create-dom-collection/utils.ts
@@ -6,7 +6,7 @@
  * https://github.com/ariakit/ariakit/blob/da142672eddefa99365773ced72171facc06fdcb/packages/ariakit/src/collection/collection-state.ts
  */
 
-import { type Accessor, createEffect } from "solid-js";
+import { type Accessor, createEffect, untrack } from "solid-js";
 
 import type { DomCollectionItem } from "./types.ts";
 
@@ -123,7 +123,7 @@ function createTimeoutObserver<T extends DomCollectionItem = DomCollectionItem>(
 		() => {},
 		() => {
 			const timeout = setTimeout(() => {
-				setItemsBasedOnDOMPosition(items(), setItems);
+				setItemsBasedOnDOMPosition(untrack(() => items()), setItems);
 			});
 			return () => clearTimeout(timeout);
 		},
@@ -146,21 +146,21 @@ export function createSortBasedOnDOMPosition<
 		(currentItems) => {
 			const callback = () => {
 				const hasPreviousItems = !!previousItems.length;
-				previousItems = items();
+				previousItems = untrack(() => items());
 
 				// We don't want to sort items if items have been just registered.
 				if (!hasPreviousItems) {
 					return;
 				}
 
-				setItemsBasedOnDOMPosition(items(), setItems);
+				setItemsBasedOnDOMPosition(untrack(() => items()), setItems);
 			};
 
 			const root = getCommonParent(currentItems);
 			const observer = new IntersectionObserver(callback, { root });
 
 			for (const item of currentItems) {
-				const itemEl = item.ref();
+				const itemEl = untrack(() => item.ref());
 
 				if (itemEl) {
 					observer.observe(itemEl);

--- a/packages/core/src/primitives/create-dom-collection/utils.ts
+++ b/packages/core/src/primitives/create-dom-collection/utils.ts
@@ -123,7 +123,10 @@ function createTimeoutObserver<T extends DomCollectionItem = DomCollectionItem>(
 		() => {},
 		() => {
 			const timeout = setTimeout(() => {
-				setItemsBasedOnDOMPosition(untrack(() => items()), setItems);
+				setItemsBasedOnDOMPosition(
+					untrack(() => items()),
+					setItems,
+				);
 			});
 			return () => clearTimeout(timeout);
 		},
@@ -153,7 +156,10 @@ export function createSortBasedOnDOMPosition<
 					return;
 				}
 
-				setItemsBasedOnDOMPosition(untrack(() => items()), setItems);
+				setItemsBasedOnDOMPosition(
+					untrack(() => items()),
+					setItems,
+				);
 			};
 
 			const root = getCommonParent(currentItems);

--- a/packages/core/src/tabs/tabs-indicator.tsx
+++ b/packages/core/src/tabs/tabs-indicator.tsx
@@ -10,7 +10,7 @@ import type { Orientation } from "@kobalte/utils";
 import { combineStyle } from "@solid-primitives/props";
 import { createResizeObserver } from "@solid-primitives/resize-observer";
 import type { JSX, ValidComponent } from "@solidjs/web";
-import { createEffect, createSignal, omit, onSettled } from "solid-js";
+import { createEffect, createSignal, omit, onSettled, untrack } from "solid-js";
 import { useLocale } from "../i18n/index.tsx";
 import {
 	type ElementOf,
@@ -95,7 +95,7 @@ export function TabsIndicator<T extends ValidComponent = "div">(
 	// before computing the style.
 	onSettled(() => {
 		queueMicrotask(() => {
-			computeStyle();
+			untrack(() => computeStyle());
 		});
 	});
 
@@ -103,7 +103,7 @@ export function TabsIndicator<T extends ValidComponent = "div">(
 	createEffect(
 		() => [context.selectedTab(), context.orientation(), direction()] as const,
 		() => {
-			computeStyle();
+			untrack(() => computeStyle());
 		},
 		{ defer: true },
 	);
@@ -115,6 +115,7 @@ export function TabsIndicator<T extends ValidComponent = "div">(
 	createResizeObserver(context.selectedTab, (_, t) => {
 		if (prevTarget !== t) {
 			prevTarget = t;
+			untrack(() => computeStyle());
 			return;
 		}
 
@@ -128,7 +129,7 @@ export function TabsIndicator<T extends ValidComponent = "div">(
 			setResizing(false);
 		}, 1);
 
-		computeStyle();
+		untrack(() => computeStyle());
 	});
 
 	return (


### PR DESCRIPTION
Fixes STRICT_READ_UNTRACKED warnings in Solid 2.0 strict mode.

### Problem
Dev warns 12x:

[STRICT_READ_UNTRACKED] Reactive value read directly in an effect callback will not update.

Sites:
- src/primitives/create-dom-collection/utils.ts — createTimeoutObserver and createSortBasedOnDOMPosition read items()/item.ref() in effect/observer callbacks. These are one-time DOM-position setup; currentItems param already drives the effect.
- src/tabs/tabs-indicator.tsx — computeStyle() reads selectedTab/direction/orientation/style() inside on([selectedTab, orientation, direction], ...) and createResizeObserver callbacks. Deps are already tracked via on(...), inner reads should be untracked.

Related: #717 — same Solid 2 hydration strictness that broke Button/Polymorphic via Dynamic.

### Fix
Wrap one-time reads in untrack():

- create-dom-collection/utils.ts: untrack(() => items()), untrack(() => item.ref())
- tabs-indicator.tsx: untrack(() => computeStyle()) / untrack(() => style())

Effect still re-runs when tracked deps change, but inner reads no longer warn.

### Repro
SSR + hydrate any page with Tabs (or List via createDomCollection). Before: 12 warnings. After: 0, hydration PASS.