### PR TITLE
docs: fix ColorArea anatomy example

### DIFF
--- a/apps/docs/src/routes/docs/core/(1)components/color-area.mdx
+++ b/apps/docs/src/routes/docs/core/(1)components/color-area.mdx
@@ -61,7 +61,7 @@ The color area consists of:
       <ColorArea.HiddenInputX />
       <ColorArea.HiddenInputY />
     </ColorArea.Thumb>
-  </ColorArea.Track>
+  </ColorArea.Background>
 </ColorArea>
 ```
 


### PR DESCRIPTION
Fix the incorrect closing tag in the `ColorArea` anatomy example.

`ColorArea.Background` was incorrectly closed with `ColorArea.Track`.
